### PR TITLE
Fixed crash Caused by java.lang.IllegalStateException

### DIFF
--- a/android/src/main/java/com/llfbandit/record/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/llfbandit/record/MethodCallHandlerImpl.java
@@ -58,13 +58,15 @@ public class MethodCallHandlerImpl implements MethodCallHandler, PluginRegistry.
   @Override
   public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     if (requestCode == RECORD_AUDIO_REQUEST_CODE) {
-      if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        pendingPermResult.success(true);
-      } else {
-        pendingPermResult.error("-2", "Permission denied", null);          
+      if(pendingPermResult != null){
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+          pendingPermResult.success(true);
+        } else {
+          pendingPermResult.error("-2", "Permission denied", null);
+        }
+        pendingPermResult = null;
+        return true;
       }
-      pendingPermResult = null;
-      return true;
     }
 
     return false;

--- a/android/src/main/java/com/llfbandit/record/Recorder.java
+++ b/android/src/main/java/com/llfbandit/record/Recorder.java
@@ -56,9 +56,13 @@ class Recorder {
     if (recorder != null) {
       Log.d(LOG_TAG, "Stop recording");
 
-      recorder.stop();
-      recorder.reset();
-      recorder.release();
+      try {
+        recorder.stop();
+        recorder.reset();
+        recorder.release();
+      } catch (Exception e) {
+        Log.d(LOG_TAG, "Stop failed");
+      }
       recorder = null;
       isRecording = false;
     }


### PR DESCRIPTION
Caused by java.lang.IllegalStateException

android.media.MediaRecorder.native_stop (MediaRecorder.java)
android.media.MediaRecorder.stop (MediaRecorder.java:1886)
com.llfbandit.record.Recorder.stopRecording (Recorder.java:59)
com.llfbandit.record.Recorder.close (Recorder.java:52)
com.llfbandit.record.MethodCallHandlerImpl.close (MethodCallHandlerImpl.java:29)
com.llfbandit.record.RecordPlugin.stopPlugin (RecordPlugin.java:78)
com.llfbandit.record.RecordPlugin.onDetachedFromActivity (RecordPlugin.java:61)
io.flutter.embedding.engine.FlutterEngineConnectionRegistry.detachFromActivity (FlutterEngineConnectionRegistry.java:389)
io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onDetach (FlutterActivityAndFragmentDelegate.java:539)
io.flutter.embedding.android.FlutterActivity.release (FlutterActivity.java:589)
io.flutter.embedding.android.FlutterActivity.onDestroy (FlutterActivity.java:610)