### PR TITLE
Allow recording through bluetooth headsets on iOS

### DIFF
--- a/ios/Classes/SwiftRecordPlugin.swift
+++ b/ios/Classes/SwiftRecordPlugin.swift
@@ -81,7 +81,11 @@ public class SwiftRecordPlugin: NSObject, FlutterPlugin, AVAudioRecorderDelegate
     ] as [String : Any]
 
     do {
-      try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playAndRecord, options: AVAudioSession.CategoryOptions.defaultToSpeaker)
+      var options: AVAudioSession.CategoryOptions = [.defaultToSpeaker, .allowBluetooth]
+      if #available(iOS 10.0, *) {
+        options.insert(.allowBluetoothA2DP)
+      }
+      try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playAndRecord, options: options)
       try AVAudioSession.sharedInstance().setActive(true)
 
       audioRecorder = try AVAudioRecorder(url: URL(string: path)!, settings: settings)


### PR DESCRIPTION
I noticed that when using a bluetooth headsets on iOS, starting the recording will choose an audio route that doesn't use the headset at all. Bluetooth has to be explicitly allowed on the audio session for this to work. I think on Android, it just works.

Since for my use case I definitely want to record through the headset when one is connected, I created this fix for myself. I think this might be useful for others as well, so would you consider merging this into the project? If you're not keen on always enabling bluetooth, I could also add another option to control this behavior.