### PR TITLE
Fix handling of file path URLs on iOS

### DIFF
--- a/ios/Classes/SwiftRecordPlugin.swift
+++ b/ios/Classes/SwiftRecordPlugin.swift
@@ -84,7 +84,8 @@ public class SwiftRecordPlugin: NSObject, FlutterPlugin, AVAudioRecorderDelegate
       try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playAndRecord, options: AVAudioSession.CategoryOptions.defaultToSpeaker)
       try AVAudioSession.sharedInstance().setActive(true)
 
-      audioRecorder = try AVAudioRecorder(url: URL(string: path)!, settings: settings)
+      let url = URL(string: path) ?? URL(fileURLWithPath: path)
+      audioRecorder = try AVAudioRecorder(url: url, settings: settings)
       audioRecorder!.delegate = self
       audioRecorder!.record()
 


### PR DESCRIPTION
This fixes handling of file path URLs handed into `Record.start` on iOS.

Without this fix, app do crash on iOS since `URL(string: path)` does return `nil` in some cases. To properly convert file path string (e.g. `/Users/user/Library/Developer/CoreSimulator/Devices/91CADEBD-DD43-4917-990C-0C946306F3E4/data/Containers/Data/Application/E555953D-4438-4E8C-89D4-02576082A0AE/Library/Application Support/audio/30ce8b5c-7ff3-4a1f-adf6-1ace9695dcc5.m4a`) into a URL`URL(fileURLWithPath: path)` has to be used.

See the documentation about [init(string:)](https://developer.apple.com/documentation/foundation/nsurl/1413146-init) and [init(fileURLWithPath:relativeTo:)](https://developer.apple.com/documentation/foundation/nsurl/1415077-init) for further information.