### PR TITLE
Use averagePower for decibel level on iOS

### DIFF
--- a/record/ios/Classes/SwiftRecordPlugin.swift
+++ b/record/ios/Classes/SwiftRecordPlugin.swift
@@ -153,7 +153,7 @@ public class SwiftRecordPlugin: NSObject, FlutterPlugin, AVAudioRecorderDelegate
     if isRecording {
       audioRecorder?.updateMeters()
       
-      let current = audioRecorder?.peakPower(forChannel: 0)
+      let current = audioRecorder?.averagePower(forChannel: 0)
 
       if (current! > maxAmplitude) {
         maxAmplitude = current!;


### PR DESCRIPTION
averagePower was more useful when creating a UI for feedback during recording as it "decays" faster and the readouts are more real time.

If you make a loud noise while recording and are calling `getAmplitude` rapidly (every 100ms in my case) when you make a loud noise the readout doesn't go back to a lower decibel level as expected when using peakPower readouts. It will remain high for a few moments before dropping back down.

For real time recording level feedback, `averagePower` was more effective.