### PR TITLE
use absolute path to call fmedia binary

### DIFF
--- a/record_linux/lib/record_linux.dart
+++ b/record_linux/lib/record_linux.dart
@@ -4,8 +4,15 @@ import 'dart:math';
 import 'package:path/path.dart' as p;
 import 'package:record_platform_interface/record_platform_interface.dart';
 
-///relative path to
-const _assetsDir = 'data/flutter_assets/packages/record_linux/assets/fmedia';
+/// uri of executable file
+final _uri = File(Platform.resolvedExecutable).uri;
+
+/// Absolut path to package assets.
+///
+/// By default data folder is in the same directory as executable.
+final _assetsDir = p.join(_uri.path.substring(
+    0, _uri.path.length - _uri.pathSegments.last.length),
+    'data/flutter_assets/packages/record_linux/assets/fmedia');
 
 const _pipeProcName = 'record_linux';
 


### PR DESCRIPTION
There is no guarantee that current dir will be the same as dir with flutter executable(where is a "data" dir by default), 
it is better to assume that near flutter executable will be "data" directory which is needed to app.

BTW:
latest release of record_linux still have two issue:
1) fmedia from asset didn't have executable permission, my fix is very ugly, so it is NOT part of pull request, but here it is anyway: 
```
    return Process.start('$_assetsDir/fmedia', [
      '--globcmd.pipe-name=$_pipeProcName',
      ...arguments,
    ]).catchError((Object err) {
      // is there better way to get executable permission?
      // look like there isn't: https://github.com/dart-lang/sdk/issues/15078
      // maybe add hook to build script?
      Process.start('chmod', ['755', '$_assetsDir/fmedia']);
      return Process.start('$_assetsDir/fmedia', [
        '--globcmd.pipe-name=$_pipeProcName',
        ...arguments,
      ]);
    });
```
2) fmedia didn't record on opensuse - will try to investigate late...