### PR TITLE
chore: Disable broken linux support

### DIFF
--- a/record/README.md
+++ b/record/README.md
@@ -1,7 +1,7 @@
 Audio recorder from microphone to a given file path.  
 No external dependencies, MediaRecorder is used for Android an AVAudioRecorder for iOS.  
 
-On Windows and linux, encoding is provided by [fmedia](https://stsaz.github.io/fmedia/).  
+On Windows, encoding is provided by [fmedia](https://stsaz.github.io/fmedia/).  
 
 On macOS, AVCaptureSession (included in SDK).
 
@@ -47,21 +47,21 @@ min SDK: 10.15
 | pause/resume     | ✔️             |   ✔️           | ✔️     |      ✔️    | ✔️    |  ✔️
 | amplitude(dBFS)  | ✔️             |   ✔️           |         |            |  ✔️   |
 | permission check | ✔️             |   ✔️           |  ✔️    |            |  ✔️   |
-| num of channels  | ✔️             |   ✔️           |  ✔️    |    ✔️      |  ✔️   |  ✔️
-| device selection |                | (auto BT/mic)   |  ✔️    |    ✔️      |  ✔️   |  ✔️
+| num of channels  | ✔️             |   ✔️           |  ✔️    |    ✔️      |  ✔️   |
+| device selection |                | (auto BT/mic)   |  ✔️    |    ✔️      |  ✔️   |
 
 
 | Encoder         | Android        | iOS     | web     | Windows | macOS   | linux
 |-----------------|----------------|---------|---------|---------|---------|---------
-| aacLc           | ✔️            |   ✔️    |  ?      |   ✔️    |  ✔️    |  ✔️ 
-| aacEld          | ✔️            |   ✔️    |  ?      |         |  ✔️    | 
-| aacHe           | ✔️            |   ✔️    |  ?      |   ✔️    |  ✔️    |  ✔️ 
+| aacLc           | ✔️            |   ✔️    |  ?      |   ✔️    |  ✔️    |
+| aacEld          | ✔️            |   ✔️    |  ?      |         |  ✔️    |
+| aacHe           | ✔️            |   ✔️    |  ?      |   ✔️    |  ✔️    |  
 | amrNb           | ✔️            |   ✔️    |  ?      |         |  ✔️    |  
 | amrWb           | ✔️            |   ✔️    |  ?      |          |  ✔️   |  
-| opus            | ✔️            |   ✔️    |  ?      |   ✔️    |  ✔️    |  ✔️ 
-| vorbisOgg       | ?(optional)   |          |  ?      |  ✔️     |        |   ✔️  
-| wav             |  ✔️           |         |  ?      |   ✔️     |        |   ✔️ 
-| flac            |               |    ✔️    |  ?      |  ✔️     |   ✔️  |   ✔️
+| opus            | ✔️            |   ✔️    |  ?      |   ✔️    |  ✔️    |  
+| vorbisOgg       | ?(optional)   |          |  ?      |  ✔️     |        |   
+| wav             |  ✔️           |         |  ?      |   ✔️     |        |   
+| flac            |               |    ✔️    |  ?      |  ✔️     |   ✔️  |  
 | pcm8bit         | ✔️            |   ✔️    |  ?      |          |  ✔️   |  
 | pcm16bit        | ✔️            |   ✔️    |  ?      |          |  ✔️   |  
 
@@ -77,7 +77,7 @@ If a given encoder is not supported when starting recording on platform, the fal
 | web         | OPUS OGG (not guaranteed => choice is made by the browser)   
 | Windows     | AAC LC                                                       
 | macOS       | AAC LC                                                       
-| linux       | AAC LC                                                       
+                                                     
 
 ## Encoding API levels documentation
 ### Android

--- a/record/pubspec.yaml
+++ b/record/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
   record_web: '>=0.5.0 < 2.0.0'
   record_windows: '>=0.6.2 < 2.0.0'
   record_macos: '>=0.2.2 < 2.0.0'
-  record_linux: '>=0.3.3 < 2.0.0'
+#  Removed until https://github.com/llfbandit/record/issues/95 is fixed
+#  record_linux: '>=0.3.3 < 2.0.0'
 
 # dependency_overrides:
 #   record_platform_interface:
@@ -48,5 +49,6 @@ flutter:
         default_package: record_windows
       macos:
         default_package: record_macos
-      linux:
-        default_package: record_linux
+#  Removed until https://github.com/llfbandit/record/issues/95 is fixed
+#      linux:
+#        default_package: record_linux


### PR DESCRIPTION
Until https://github.com/llfbandit/record/issues/95 is fixed and fmedia is provied not via a blob in the source code