### PR TITLE
Fix example on README.md

### DIFF
--- a/record/README.md
+++ b/record/README.md
@@ -105,7 +105,7 @@ if (await record.hasPermission()) {
     path: 'aFullPath/myFile.m4a',
     encoder: AudioEncoder.aacLc, // by default
     bitRate: 128000, // by default
-    sampleRate: 44100, // by default
+    samplingRate: 44100, // by default
   );
 }
 


### PR DESCRIPTION
When I copy the example, I got error `The named parameter 'sampleRate' isn't defined`.

So, I believe this is should be `samplingRate` , instead of `sampleRate` based on the method definition below :

![image](https://github.com/llfbandit/record/assets/39850621/43b604f9-f267-49bb-abd0-80dfbff42f76)
