### PR TITLE
fix: Adding events to amplitude stream after close

### DIFF
--- a/record/lib/src/record.dart
+++ b/record/lib/src/record.dart
@@ -33,11 +33,10 @@ class AudioRecorder {
     try {
       await RecordPlatform.instance.create(_recorderId);
 
-      _stateStreamSubscription =
-          RecordPlatform.instance.onStateChanged(_recorderId).listen(
-                _stateStreamCtrl.add,
-                onError: _stateStreamCtrl.addError,
-              );
+      _stateStreamSubscription = RecordPlatform.instance.onStateChanged(_recorderId).listen(
+            _stateStreamCtrl.add,
+            onError: _stateStreamCtrl.addError,
+          );
 
       _createCompleter.complete();
     } catch (e, stackTrace) {
@@ -162,6 +161,7 @@ class AudioRecorder {
     _amplitudeStreamCtrl?.close();
     _amplitudeTimer?.cancel();
     _stateStreamSubscription.cancel();
+    _amplitudeStreamCtrl = null;
 
     await RecordPlatform.instance.dispose(_recorderId);
 
@@ -202,7 +202,8 @@ class AudioRecorder {
     }
 
     if (await shouldUpdate()) {
-      _amplitudeStreamCtrl?.add(await getAmplitude());
+      final amplitude = await getAmplitude();
+      _amplitudeStreamCtrl?.add(amplitude);
     }
   }
 


### PR DESCRIPTION
It was possible that `_amplitudeStreamCtrl?.add(await getAmplitude());` would result in a `Bad state: Cannot add event after closing` error, because `getAmplitude()` could complete after the amplitude stream controller was closed. It didn't have any noticeable effect of the functioning of an app as far as I can tell, but our error log was getting quite flooded by these.