### PR TITLE
Add support of namespace property to support Android Gradle Plugin 8

### DIFF
--- a/record_android/android/build.gradle
+++ b/record_android/android/build.gradle
@@ -28,6 +28,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
+    if (project.android.hasProperty('namespace')) {
+        namespace 'com.llfbandit.record'
+    }
+    
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
Add support of namespace property to support Android Gradle Plugin 8