### PR TITLE
fix(Android) Fixed a bug that audio file cannot be played when using OMX.google.aac.encoder

### DIFF
--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/encoder/MediaCodecEncoder.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/encoder/MediaCodecEncoder.kt
@@ -1,9 +1,11 @@
 package com.llfbandit.record.record.encoder
 
+import android.annotation.TargetApi
 import android.media.MediaCodec
 import android.media.MediaCodec.CodecException
 import android.media.MediaCodecList
 import android.media.MediaFormat
+import android.os.Build
 import com.llfbandit.record.record.container.IContainerWriter
 
 class MediaCodecEncoder(
@@ -30,15 +32,32 @@ class MediaCodecEncoder(
         container.release()
     }
 
-    private fun createCodec(mediaFormat: MediaFormat): MediaCodec {
-        var encoder =
-            MediaCodecList(MediaCodecList.REGULAR_CODECS).findEncoderForFormat(mediaFormat)
-                ?: throw Exception("No encoder found for $mediaFormat")
+    @TargetApi(Build.VERSION_CODES.Q)
+    private fun findCodecForFormat(format: MediaFormat): String? {
+        val mime = format.getString(MediaFormat.KEY_MIME)
+        val codecs = MediaCodecList(MediaCodecList.REGULAR_CODECS)
 
-        val isSdk29OrAbove = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
-        if (isSdk29OrAbove) {
-            encoder = encoder.replace("OMX.google", "c2.android")
+        for (info in codecs.codecInfos.sortedBy { !it.canonicalName.startsWith("c2.android") }) {
+            if (!info.isEncoder) {
+                continue
+            }
+            try {
+                val caps = info.getCapabilitiesForType(mime)
+                if (caps != null && caps.isFormatSupported(format)) {
+                    return info.canonicalName
+                }
+            } catch (e: IllegalArgumentException) {
+                // type is not supported
+            }
         }
+        return null
+    }
+
+    private fun createCodec(mediaFormat: MediaFormat): MediaCodec {
+        val isSdk28OrBelow = android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.P
+        var encoder = if (isSdk28OrBelow) MediaCodecList(MediaCodecList.REGULAR_CODECS).findEncoderForFormat(mediaFormat)
+                      else findCodecForFormat(mediaFormat)
+                      ?: throw Exception("No encoder found for $mediaFormat")
 
         val codec = MediaCodec.createByCodecName(encoder)
 


### PR DESCRIPTION
Thanks for the great library.

There seems to be a bug in `record@v5.0.1` that when the Android version is over 10 and OMX.google.* is used, the length of the audio file cannot be obtained.
I verified it using [audioplayers](https://github.com/bluefireteam/audioplayers) and [just_audio](https://github.com/ryanheise/just_audio), but null is returned.
When I verified it using multiple Android 10s, I found that the length of the audio file can be obtained when using the `c2.android.*` codec.
So, when the Android version is over 10, I changed it to use the `c2.android.*` codec.