### PR TITLE
Handle disposing when _stateStreamSubscription has not been initialised

### DIFF
--- a/record/lib/src/record.dart
+++ b/record/lib/src/record.dart
@@ -161,7 +161,10 @@ class AudioRecorder {
     _amplitudeStreamCtrl?.close();
     _amplitudeStreamCtrl = null;
 
-    _stateStreamSubscription?.cancel();
+    if (_stateStreamSubscription != null) {
+      await _stateStreamSubscription.cancel();
+      _stateStreamSubscription = null;
+    }
     _stateStreamCtrl.close();
 
     await RecordPlatform.instance.dispose(_recorderId);


### PR DESCRIPTION
To fix this error ... 

[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: PlatformException(record, Recorder has not yet been created or has already been disposed., null, null)
#0      StandardMethodCodec.decodeEnvelope (package:flutter/src/services/message_codecs.dart:651:7)
#1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:322:18)
<asynchronous suspension>
#2      RecordMethodChannel.dispose (package:record_platform_interface/src/record_method_channel.dart:112:5)
<asynchronous suspension>
#3      AudioRecorder.dispose (package:record/src/record.dart:167:5)
<asynchronous suspension>

Related to: https://github.com/llfbandit/record/issues/263