### PR TITLE
Fixing relative asset paths for subfolders in Flutter Web

### DIFF
--- a/record_web/lib/recorder/delegate/mic_recorder_delegate.dart
+++ b/record_web/lib/recorder/delegate/mic_recorder_delegate.dart
@@ -114,7 +114,7 @@ class MicRecorderDelegate extends RecorderDelegate {
     final source = context.createMediaStreamSource(mediaStream);
 
     await context.audioWorklet.addModule(
-      '/assets/packages/record_web/assets/js/record.worklet.js',
+      './assets/packages/record_web/assets/js/record.worklet.js',
     );
 
     final recorder = AudioWorkletNode(


### PR DESCRIPTION
### **Issue**
When deploying a Flutter web application to a subfolder and serving it with a simple HTTP server, a 404 error is encountered for assets due to incorrect relative paths.

### **Steps to Reproduce**

Create an example Flutter application and include the _record_ package.

Build the release version with the following command:
`flutter build web --release --base-href /client/`

Move the release files to a subfolder:
`mkdir -p release/client && cp -a build/web/* release/client`

Serve the application using an HTTP server:
`http-server release`

Trigger in the example app the function 
`recorder.start(const RecordConfig(encoder: AudioEncoder.wav)`

Observe the 404 error for assets due to incorrect paths (/assets/package/... instead of /client/assets/package/...).

### **Proposed Fix**
Modify the asset path to a relative asset path.

### **Expected Behavior**
After applying the fix, the assets should be successfully loaded without 404 errors when serving the Flutter web application from a subfolder.

### **Flutter doctor**
```
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.16.7, on macOS 14.2.1 23C71 darwin-arm64, locale es-DE)
[✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0-rc2)
[✓] Xcode - develop for iOS and macOS (Xcode 15.0.1)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2023.1)
[✓] VS Code (version 1.85.1)
[✓] Connected device (2 available)
[✓] Network resources
```
