### PR TITLE
Add iOS echo cancellation support

### DIFF
--- a/record/README.md
+++ b/record/README.md
@@ -19,7 +19,7 @@ External dependencies:
 | num of channels  | ✔️            |   ✔️           |  ✔️    |    ✔️      |  ✔️   |  ✔️
 | device selection | ✔️ *          | (auto BT/mic)   |  ✔️    |    ✔️      |  ✔️   |  ✔️
 | auto gain        | ✔️            |(always active?)| ✔️      |            |       |  
-| echo cancel      | ✔️            |                 | ✔️      |            |       |  
+| echo cancel      | ✔️            |   ✔ (if target set to iOS 13.0+) | ✔️      |            |       |  
 | noise suppresion | ✔️            |                 | ✔️      |            |       |  
 
 * min SDK: 23. Bluetooth telephony device link (SCO) is automatically done but there's no phone call management.

--- a/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
+++ b/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
@@ -22,15 +22,20 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     )
 
     if config.echoCancel {
-      if #available(iOS 13.0, *) {
-        do {
-          try inputNode.setVoiceProcessingEnabled(true)
-        } catch {
-          throw RecorderError.error(
-            message: "Failed to start recording",
-            details: "Failed to enable echo cancellation: \(error.localizedDescription)"
-          )
-        }
+      guard #available(iOS 13, *) else {
+        throw RecorderError.error(
+          message: "Failed to start recording",
+          details: "Echo cancellation only available on iOS 13 and above."
+        )
+      }
+
+      do {
+        try inputNode.setVoiceProcessingEnabled(true)
+      } catch {
+        throw RecorderError.error(
+          message: "Failed to start recording",
+          details: "Failed to enable echo cancellation: \(error.localizedDescription)"
+        )
       }
     }
 

--- a/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
+++ b/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
@@ -21,6 +21,19 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
       interleaved: true
     )
 
+    if config.echoCancel {
+      if #available(iOS 13.0, *) {
+        do {
+          try inputNode.setVoiceProcessingEnabled(true)
+        } catch {
+          throw RecorderError.error(
+            message: "Failed to start recording",
+            details: "Failed to enable echo cancellation: \(error.localizedDescription)"
+          )
+        }
+      }
+    }
+
     guard let dstFormat = dstFormat else {
       throw RecorderError.error(
         message: "Failed to start recording",

--- a/record_darwin/darwin/record_darwin.podspec
+++ b/record_darwin/darwin/record_darwin.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     s.public_header_files = 'Classes/**/*.h'
     s.ios.dependency 'Flutter'
     s.osx.dependency 'FlutterMacOS'
-    s.ios.deployment_target = '13.0'
+    s.ios.deployment_target = '11.0'
     s.osx.deployment_target = '10.15'
     s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   end

--- a/record_darwin/darwin/record_darwin.podspec
+++ b/record_darwin/darwin/record_darwin.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     s.public_header_files = 'Classes/**/*.h'
     s.ios.dependency 'Flutter'
     s.osx.dependency 'FlutterMacOS'
-    s.ios.deployment_target = '11.0'
+    s.ios.deployment_target = '13.0'
     s.osx.deployment_target = '10.15'
     s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   end


### PR DESCRIPTION
Adds iOS echo cancellation support via the [setVoiceProcessingEnabled](https://developer.apple.com/documentation/avfaudio/avaudioionode/3152100-setvoiceprocessingenabled) flag on the input AudioIONode.

The API is only available on iOS 13.0+, so the feature is flagged off to that deployment target, and the README has been updated to reflect that developers will need to make sure their deployment target is 13 or greater in order to benefit from the feature.

Fixes #247 