### PR TITLE
import dartjs to use allowInterop

### DIFF
--- a/record_web/lib/recorder/delegate/media_recorder_delegate.dart
+++ b/record_web/lib/recorder/delegate/media_recorder_delegate.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 import 'dart:js_util' as jsu;
+import 'dart:js' as js;
 
 import 'package:flutter/foundation.dart';
 import 'package:record_platform_interface/record_platform_interface.dart';
@@ -109,8 +110,8 @@ class MediaRecorderDelegate extends RecorderDelegate {
           mimeType: mimeType,
         ),
       );
-      mediaRecorder.ondataavailable = jsu.allowInterop(_onDataAvailable);
-      mediaRecorder.onstop = jsu.allowInterop(_onStop);
+      mediaRecorder.ondataavailable = js.allowInterop(_onDataAvailable);
+      mediaRecorder.onstop = js.allowInterop(_onStop);
 
       _elapsedTime.start();
 

--- a/record_web/lib/recorder/delegate/mic_recorder_delegate.dart
+++ b/record_web/lib/recorder/delegate/mic_recorder_delegate.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:js_util' as jsu;
+import 'dart:js' as js;
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -142,7 +143,7 @@ class MicRecorderDelegate extends RecorderDelegate {
       }
     }
 
-    recorder.port.onmessage = jsu.allowInterop(
+    recorder.port.onmessage = js.allowInterop(
       (event) {
         if (isStream) {
           _onMessageStream(event as MessageEvent);


### PR DESCRIPTION
based on documentation of dart allowInterop is in package:js

[](https://api.dart.dev/stable/2.7.2/dart-js/allowInterop.html)
https://api.dart.dev/stable/2.7.2/dart-js/allowInterop.html

> Returns a wrapper around function f that can be called from JavaScript using package:js JavaScript interop.