### PR TITLE
fix(macos): correct incorrect PCM16 Audio Stream data #336

### DIFF
--- a/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
+++ b/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
@@ -133,7 +133,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     }
     
     // Determine frame capacity
-    let capacity = (UInt32(dstFormat.sampleRate) * dstFormat.channelCount * buffer.frameLength) / (UInt32(buffer.format.sampleRate) * buffer.format.channelCount)
+    let capacity = (UInt32(dstFormat.sampleRate) * dstFormat.channelCount * buffer.frameLength * 2) / (UInt32(buffer.format.sampleRate) * buffer.format.channelCount)
     
     // Destination buffer
     guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: capacity) else {


### PR DESCRIPTION
Incorrect buffer size for sending Streams and increasing the size