### PR TITLE
Fixed debug output when encoder is not supported

### DIFF
--- a/record/example/lib/audio_recorder.dart
+++ b/record/example/lib/audio_recorder.dart
@@ -114,7 +114,7 @@ class _RecorderState extends State<Recorder> with AudioRecorderMixin {
 
       for (final e in AudioEncoder.values) {
         if (await _audioRecorder.isEncoderSupported(e)) {
-          debugPrint('- ${encoder.name}');
+          debugPrint('- ${e.name}');
         }
       }
     }


### PR DESCRIPTION
If the selected audio recorder `aacLc` is not supported on the current platform, the supported encoders should be printed, not the name of the chosen encoder multiple times.