### PR TITLE
Darwin fixes

### DIFF
--- a/record_darwin/CHANGELOG.md
+++ b/record_darwin/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.3
 * fix: Exception where format.sampleRate != hwFormat.sampleRate
+* feat(macOS): Support device by deviceID as well as deviceUID
 
 ## 1.1.2
 * fix: Remove print on conversion error.

--- a/record_darwin/CHANGELOG.md
+++ b/record_darwin/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.3
+* fix: Exception where format.sampleRate != hwFormat.sampleRate
+
 ## 1.1.2
 * fix: Remove print on conversion error.
 

--- a/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
+++ b/record_darwin/darwin/Classes/delegate/RecorderStreamDelegate.swift
@@ -27,7 +27,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     }
 #endif
     
-    let srcFormat = audioEngine.inputNode.outputFormat(forBus: 0)
+    let srcFormat = audioEngine.inputNode.inputFormat(forBus: 0)
     
     let dstFormat = AVAudioFormat(
       commonFormat: .pcmFormatInt16,

--- a/record_darwin/macos/Classes/RecorderMacOS.swift
+++ b/record_darwin/macos/Classes/RecorderMacOS.swift
@@ -81,6 +81,11 @@ func getAudioDeviceIDFromUID(uid: String) -> AudioDeviceID? {
 
   // Get device UID
   for deviceID in deviceIDs {
+    // Support lookup by devicezID rather than uid
+    if String(deviceID) == uid {
+      return deviceID
+    }
+
     propertyAddress.mSelector = kAudioDevicePropertyDeviceUID
     propertySize = UInt32(MemoryLayout<CFString>.size)
     var deviceUID: Unmanaged<CFString>?


### PR DESCRIPTION
fix: Exception where format.sampleRate != hwFormat.sampleRate
This patch fixes an exception that crashes the app.  The exception is caused by a wrong source audio format being used for the installTap call on the input.  Instead of the inputFormat being used, the outputFormat was used which caused the exception when some devices are selected.

feat(macOS): Support device by deviceID as well as deviceUID
For compatibility with other packages which may report devices by their deviceID rather than deviceUID.  The flutter_webrtc package is an example.  This patch will match on either.  There is no overlap so the old behavior should not be impacted.