### PR TITLE
manageAudioSession option for IosRecordConfig

### DIFF
--- a/record_darwin/darwin/Classes/RecordConfig.swift
+++ b/record_darwin/darwin/Classes/RecordConfig.swift
@@ -69,6 +69,7 @@ public class Device {
 
 struct IosConfig {
   let audioCategories: [AVAudioSession.CategoryOptions]
+  let manageAudioSession: Bool
 
   init(map: [String: Any]) {
     let comps = map["audioCategories"] as? String
@@ -94,5 +95,6 @@ struct IosConfig {
       }
     }
     self.audioCategories = options ?? []
+    self.manageAudioSession = map["manageAudioSession"] as? Bool ?? true
   }
 }

--- a/record_darwin/ios/Classes/delegate/RecorderFileDelegate.swift
+++ b/record_darwin/ios/Classes/delegate/RecorderFileDelegate.swift
@@ -8,7 +8,9 @@ class RecorderFileDelegate: NSObject, AudioRecordingFileDelegate, AVAudioRecorde
   func start(config: RecordConfig, path: String) throws {
     try deleteFile(path: path)
 
-    try initAVAudioSession(config: config)
+    if config.iosConfig?.manageAudioSession ?? true {
+      try initAVAudioSession(config: config)
+    }
 
     let url = URL(fileURLWithPath: path)
 

--- a/record_platform_interface/lib/src/types/record_config.dart
+++ b/record_platform_interface/lib/src/types/record_config.dart
@@ -120,13 +120,19 @@ class IosRecordConfig {
   /// Constants that specify optional audio behaviors.
   /// https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions
   final List<IosAudioCategories> audioCategories;
+  /// Manage the shared AVAudioSession (defaults to `true`).
+  /// Set this to false if another plugin is already managing the AVAudioSession.
+  /// If false, audioCategories config will have no effect.
+  final bool manageAudioSession;
 
   const IosRecordConfig({
-    this.audioCategories = const [IosAudioCategories.defaultToSpeaker, IosAudioCategories.allowBluetooth, IosAudioCategories.allowBluetoothA2DP]
+    this.audioCategories = const [IosAudioCategories.defaultToSpeaker, IosAudioCategories.allowBluetooth, IosAudioCategories.allowBluetoothA2DP],
+    this.manageAudioSession = true,
   });
   Map<String, dynamic> toMap() {
     return {
-      "audioCategories": audioCategories.map((e) => e.name).join(',')
+      "audioCategories": audioCategories.map((e) => e.name).join(','),
+      "manageAudioSession": manageAudioSession,
     };
   }
   


### PR DESCRIPTION
Hi there,

I'm using this plugin alongside just_audio and audio_session plugins in my app.
Because my players have to support audio route switching, I am using the audio_session plugin for it.
With this setup, I ran into the following issues when recording on iOS:
- sometimes the first 1-2 seconds of a recording is being truncated
- notifications of route changes stopped working

The reason for this is that AudioRecorder.start() also configures the shared AVAudioSession and activates it,
after I already have configured and activated it through audio_session.
This re-activation can cause a delay in audio processing when recording and also explains the cancelation of
an existing route change subscription.
~~(On Android everything is working fine, since this plugin does not touch the AudioManager attributes)~~

With the added `IosRecordConfig.manageAudioSession` option set to false, I can circumvent these issues.
It defaults to true, so no changes in default behavior.

May I also suggest a renaming of the `IosRecordConfig.audioCategories` field to `audioCategoryOptions`?
Because the category, currently hardcoded to `.playAndRecord`, is a different property of the audio session.
I think the IosRecordConfig addition has not been released yet, so no breaking change would be introduced.