### PR TITLE
Fixes a race condition when calling stop recording.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/recorder/RecordThread.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/recorder/RecordThread.kt
@@ -118,18 +118,21 @@ class RecordThread(
     }
 
     private fun stopAndRelease() {
-        mPcmReader?.stop()
-        mPcmReader?.release()
-        mPcmReader = null
+        try {
+            mPcmReader?.stop()
+            mPcmReader?.release()
+            mPcmReader = null
 
-        mEncoder?.stopEncoding()
-        mEncoder = null
+            mEncoder?.stopEncoding()
+            mEncoder = null
 
-        if (mHasBeenCanceled) {
-            Utils.deleteFile(config.path)
+            if (mHasBeenCanceled) {
+                Utils.deleteFile(config.path)
+            }
+            recorderListener.onStop()
+        } catch (ex: Exception) {
+            recorderListener.onFailure(ex)
         }
-
-        recorderListener.onStop()
     }
 
     private fun selectFormat(): Format {


### PR DESCRIPTION
Although the encode and stopEncoding functions of MediaCodecEncoder are called from the same thread, their execution order is not guaranteed. Consequently, processInputBuffer can sometimes be called after the MediaCodec.BUFFER_FLAG_END_OF_STREAM flag has been sent to the codec. This sequence causes an error where mStoppedCompleter is never completed, resulting in the call hanging indefinitely.