### PR TITLE
manageBluetoothAudio option for AndroidRecordConfig

### DIFF
--- a/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
@@ -139,6 +139,7 @@ class MethodCallHandlerImpl(
             Utils.firstNonNull(call.argument("noiseSuppress"), false),
             Utils.firstNonNull(androidConfig?.get("useLegacy") as Boolean?, false),
             Utils.firstNonNull(androidConfig?.get("muteAudio") as Boolean?, false),
+            Utils.firstNonNull(androidConfig?.get("manageBluetoothAudio") as Boolean?, true),
         )
     }
 }

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/RecorderWrapper.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/RecorderWrapper.kt
@@ -148,7 +148,9 @@ internal class RecorderWrapper(
     }
 
     private fun createRecorder(config: RecordConfig): IRecorder {
-        maybeStartBluetooth(config)
+        if (config.manageBluetoothAudio) {
+            maybeStartBluetooth(config)
+        }
 
         if (config.useLegacy) {
             return MediaRecorder(context, recorderStateStreamHandler)

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/RecordConfig.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/RecordConfig.kt
@@ -14,6 +14,7 @@ class RecordConfig(
     val noiseSuppress: Boolean = false,
     val useLegacy: Boolean = false,
     val muteAudio: Boolean = false,
+    val manageBluetoothAudio: Boolean = true,
 ) {
     val numChannels: Int = 2.coerceAtMost(1.coerceAtLeast(numChannels))
 }

--- a/record_platform_interface/lib/src/types/record_config.dart
+++ b/record_platform_interface/lib/src/types/record_config.dart
@@ -101,15 +101,21 @@ class AndroidRecordConfig {
   /// Use at your own risks!
   final bool muteAudio;
 
+  /// Try to start a bluetooth audio connection to a headset.
+  /// Defaults to [true].
+  final bool manageBluetoothAudio;
+
   const AndroidRecordConfig({
     this.useLegacy = false,
     this.muteAudio = false,
+    this.manageBluetoothAudio = true,
   });
 
   Map<String, dynamic> toMap() {
     return {
       'useLegacy': useLegacy,
       'muteAudio': muteAudio,
+      'manageBluetoothAudio': manageBluetoothAudio,
     };
   }
 }


### PR DESCRIPTION
Hi there,
similar to my other pr https://github.com/llfbandit/record/pull/401 for iOS,
this option is helpful if the AudioManager on Android is controlled by an other plugin (like audio_session).

Also, setting the new `manageBluetoothAudio` option to false, resolves an issue where playback audio quality over bluetooth was degraded after starting a recording.