### PR TITLE
Add startStream Functionality to Linux Implementation

### DIFF
--- a/record_platform_interface/lib/src/record_platform_interface.dart
+++ b/record_platform_interface/lib/src/record_platform_interface.dart
@@ -52,10 +52,7 @@ abstract class RecordPlatform extends PlatformInterface {
   ///
   /// When stopping the record, you must rely on stream close event to get
   /// full recorded data.
-  Future<Stream<Uint8List>> startStream(
-          String recorderId, RecordConfig config) =>
-      throw UnimplementedError(
-          'startStream not implemented on the current platform.');
+  Future<Stream<Uint8List>> startStream(String recorderId, RecordConfig config);
 
   /// Stops recording session and release internal recorder resource.
   ///


### PR DESCRIPTION
This merge request adds support for the `startStream` method to the Linux implementation of the `record` Flutter package. This enhancement enables applications running on Linux to capture audio data as a stream, aligning the Linux plugin's capabilities with those of other platforms.

**Summary of Changes**

- Added: Implementation of the startStream method for Linux.
- Added: Helper method _callFMediaStream to manage the fmedia process for streaming.
- Updated: Handling of audio encoders and configurations to support streaming.