### PR TITLE
Add audioManagerMode and setSpeakerphoneOn support in record_android to fix Echo Cancellation on Samsung S20

### DIFF
--- a/record/pubspec.yaml
+++ b/record/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   record_web: ^1.1.4
   record_windows: ^1.0.4
   record_linux: '>=0.5.0 <1.0.0'
-  record_android: ^1.3.0
+  record_android: ^1.3.1
   record_darwin: ^1.2.0
 
 dev_dependencies:

--- a/record_android/CHANGELOG.md
+++ b/record_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1
+* feat: Add `audioManagerMode` support to configure `AudioManager` modes for improved device compatibility for acoustic echo cancellation.
+* feat: Add `setSpeakerphoneOn` option to enable speakerphone, addressing echo issues and enabling external playback scenarios.
+* feat: Update Dart `AndroidRecordConfig` to support new options (`audioManagerMode` and `setSpeakerphoneOn`).
+
 ## 1.3.0
 * feat: Add audio source config.
 * feat: Add manageBluetooth (SCO) option.

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
@@ -1,6 +1,7 @@
 package com.llfbandit.record.methodcall
 
 import android.content.Context
+import android.media.AudioManager
 import android.media.MediaRecorder
 import android.os.Build
 import com.llfbandit.record.Utils
@@ -142,6 +143,17 @@ class MethodCallHandlerImpl(
             else -> MediaRecorder.AudioSource.DEFAULT
         }
 
+        val audioManagerMode: Int = when(androidConfig?.get("audioManagerMode")) {
+            "modeNormal" -> AudioManager.MODE_NORMAL
+            "modeRingtone" -> AudioManager.MODE_RINGTONE
+            "modeInCall" -> AudioManager.MODE_IN_CALL
+            "modeInCommunication" -> AudioManager.MODE_IN_COMMUNICATION
+            "modeCallScreening" -> AudioManager.MODE_CALL_SCREENING
+            "modeCallRedirect" -> AudioManager.MODE_CALL_REDIRECT
+            "modeCommunicationRedirect" -> AudioManager.MODE_COMMUNICATION_REDIRECT
+            else -> AudioManager.MODE_NORMAL
+        }
+
         return RecordConfig(
             call.argument("path"),
             Utils.firstNonNull(call.argument("encoder"), "aacLc"),
@@ -155,7 +167,9 @@ class MethodCallHandlerImpl(
             Utils.firstNonNull(androidConfig?.get("useLegacy") as Boolean?, false),
             Utils.firstNonNull(androidConfig?.get("muteAudio") as Boolean?, false),
             Utils.firstNonNull(androidConfig?.get("manageBluetooth") as Boolean?, true),
-            audioSource
+            Utils.firstNonNull(androidConfig?.get("setSpeakerphoneOn") as Boolean?, false),
+            audioSource,
+            audioManagerMode
         )
     }
 }

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/RecordConfig.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/RecordConfig.kt
@@ -1,6 +1,7 @@
 package com.llfbandit.record.record
 
 import android.media.AudioDeviceInfo
+import android.media.AudioManager
 import android.media.MediaRecorder
 
 class RecordConfig(
@@ -16,7 +17,10 @@ class RecordConfig(
     val useLegacy: Boolean = false,
     val muteAudio: Boolean = false,
     val manageBluetooth: Boolean = true,
-    val audioSource: Int = MediaRecorder.AudioSource.DEFAULT
+    val setSpeakerphoneOn: Boolean = false,
+    val audioSource: Int = MediaRecorder.AudioSource.DEFAULT,
+    val audioManagerMode: Int = AudioManager.MODE_NORMAL
+
 ) {
     val numChannels: Int = 2.coerceAtMost(1.coerceAtLeast(numChannels))
 }

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/recorder/AudioRecorder.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/recorder/AudioRecorder.kt
@@ -66,6 +66,12 @@ class AudioRecorder(
         if (config.muteAudio) {
             muteAudio(true)
         }
+        if (config.audioManagerMode != AudioManager.MODE_NORMAL) {
+            setupAudioManagerMode()
+        }
+        if (config.setSpeakerphoneOn) {
+            setSpeakerphoneOn()
+        }
     }
 
     override fun stop(stopCb: ((path: String?) -> Unit)?) {
@@ -153,5 +159,29 @@ class AudioRecorder(
         muteStreams.forEach { stream ->
             muteSettings[stream] = audioManager.getStreamVolume(stream)
         }
+    }
+
+    private fun setupAudioManagerMode() {
+        val config = this.config ?: return
+        if (config.audioManagerMode == null) {
+            return
+        }
+        if (config.audioManagerMode == AudioManager.MODE_NORMAL) {
+            return
+        }
+        val audioManager = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        audioManager.setMode(config.audioManagerMode ?: AudioManager.MODE_NORMAL)
+    }
+
+    private fun setSpeakerphoneOn() {
+        val config = this.config
+        if (config == null) {
+            return
+        }
+        if (config.setSpeakerphoneOn == false) {
+            return
+        }
+        val audioManager = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        audioManager.setSpeakerphoneOn(true)
     }
 }

--- a/record_android/pubspec.yaml
+++ b/record_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: record_android
 description: Android specific implementation for record package called by record_platform_interface.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/llfbandit/record/tree/master/record_android
 
 environment:

--- a/record_platform_interface/lib/src/types/android_record_config.dart
+++ b/record_platform_interface/lib/src/types/android_record_config.dart
@@ -24,6 +24,11 @@ class AndroidRecordConfig {
   /// Defaults to [true].
   final bool manageBluetooth;
 
+  /// Set the speakerphone on.
+  /// If [true], this will set the speakerphone on.
+  /// Useful on devices with echo cancellation issues.
+  final bool setSpeakerphoneOn;
+
   /// Defines the audio source.
   /// An audio source defines both a default physical source of audio signal, and a recording configuration.
   ///
@@ -32,11 +37,22 @@ class AndroidRecordConfig {
   /// Most of the time, you should use [AndroidAudioSource.defaultSource] or [AndroidAudioSource.mic].
   final AndroidAudioSource audioSource;
 
+  /// Defines the audio manager mode.
+  /// This is used to set the audio manager mode before recording.
+  ///
+  /// Switching to [AudioManagerMode.modeInCommunication] can help to resolve
+  /// acoustic echo cancellation issues on some devices (Tested on Samsung S20).
+  ///
+  /// Defaults to [AudioManagerMode.modeNormal].
+  final AudioManagerMode audioManagerMode;
+
   const AndroidRecordConfig({
     this.useLegacy = false,
     this.muteAudio = false,
     this.manageBluetooth = true,
+    this.setSpeakerphoneOn = false,
     this.audioSource = AndroidAudioSource.defaultSource,
+    this.audioManagerMode = AudioManagerMode.modeNormal,
   });
 
   Map<String, dynamic> toMap() {
@@ -44,7 +60,9 @@ class AndroidRecordConfig {
       'useLegacy': useLegacy,
       'muteAudio': muteAudio,
       'manageBluetooth': manageBluetooth,
+      'setSpeakerphoneOn': setSpeakerphoneOn,
       'audioSource': audioSource.name,
+      'audioManagerMode': audioManagerMode.name,
     };
   }
 }
@@ -63,4 +81,16 @@ enum AndroidAudioSource {
   remoteSubMix,
   unprocessed,
   voicePerformance,
+}
+
+/// Constants for Android for setting specific audio manager modes
+/// https://developer.android.com/reference/kotlin/android/media/AudioManager#setmode
+enum AudioManagerMode {
+  modeNormal,
+  modeRingtone,
+  modeInCall,
+  modeInCommunication,
+  modeCallScreening,
+  modeCallRedirect,
+  modeCommunicationRedirect,
 }


### PR DESCRIPTION
### Description  
- Bumped `record_android` to version `1.3.1`.  
- **Features:**  
  - Added `audioManagerMode` to configure `AudioManager` modes to fix echo cancellation issues on some Android devices (verified on Samsung S20).  
  - Added `setSpeakerphoneOn` option to enable speakerphone, addressing echo issues and external playback needs.  
- Updated `pubspec.yaml` to reference `record_android` version `1.3.1`.  
- Updated `AndroidRecordConfig` in Dart to support the new options.  

These changes enhance recording capabilities by improving echo cancellation compatibility across devices, with specific testing on the Samsung S20.