### PR TITLE
Prevent broken recordings on iOS on app termination

### DIFF
--- a/record_darwin/darwin/Classes/SwiftRecordPlugin.swift
+++ b/record_darwin/darwin/Classes/SwiftRecordPlugin.swift
@@ -22,6 +22,7 @@ public class SwiftRecordPlugin: NSObject, FlutterPlugin {
     let instance = SwiftRecordPlugin(binaryMessenger: binaryMessenger)
     
     registrar.addMethodCallDelegate(instance, channel: methodChannel)
+    registrar.addApplicationDelegate(instance)
   }
   
   // MARK: Plugin
@@ -31,6 +32,10 @@ public class SwiftRecordPlugin: NSObject, FlutterPlugin {
   
   init(binaryMessenger: FlutterBinaryMessenger) {
     self.m_binaryMessenger = binaryMessenger
+  }
+  
+  public func applicationWillTerminate(_ application: UIApplication) {
+    dispose()
   }
   
   public func detachFromEngine(for registrar: FlutterPluginRegistrar) {


### PR DESCRIPTION
These changes address an issue on iOS and MacOS where the recording results in a broken audio file if the app is closed while recording. The solution was to handle app termination (`applicationWillTerminate`) from within the plugin and simply dispose. This resembles the `detachFromEngine` handler. I thought `detachFromEngine` would be invoked on app close, but it is not.

Surprisingly, this is not an issue on Android. Android must stop the recording by default when the app is closed. Linux and Windows might have the same issue.