### PR TITLE
fix(web): specify audio object type for m4a codecs

### DIFF
--- a/record/example/macos/Podfile.lock
+++ b/record/example/macos/Podfile.lock
@@ -25,11 +25,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/record_darwin/macos
 
 SPEC CHECKSUMS:
-  audioplayers_darwin: dcad41de4fbd0099cb3749f7ab3b0cb8f70b810c
+  audioplayers_darwin: 761f2948df701d05b5db603220c384fb55720012
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  record_darwin: a0d515a0ef78c440c123ea3ac76184c9927a94d6
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  record_darwin: 30509266ae213af8afdb09a8ae7467cb64c1377e
 
 PODFILE CHECKSUM: 0d3963a09fc94f580682bd88480486da345dc3f0
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/record/example/macos/Runner/AppDelegate.swift
+++ b/record/example/macos/Runner/AppDelegate.swift
@@ -6,4 +6,8 @@ class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+    return true
+  }
 }

--- a/record_web/lib/mime_types.dart
+++ b/record_web/lib/mime_types.dart
@@ -4,9 +4,9 @@ import 'package:record_platform_interface/record_platform_interface.dart';
 
 const mimeTypes = {
   // We apply same mime types for different encoding types for AAC
-  AudioEncoder.aacLc: ['audio/mp4;codecs=mp4a', 'audio/aac'],
-  AudioEncoder.aacEld: ['audio/mp4;codecs=mp4a', 'audio/aac'],
-  AudioEncoder.aacHe: ['audio/mp4;codecs=mp4a', 'audio/aac'],
+  AudioEncoder.aacLc: ['audio/mp4;codecs=mp4a', 'audio/mp4;codecs=mp4a.40.2', 'audio/aac'],
+  AudioEncoder.aacEld: ['audio/mp4;codecs=mp4a', 'audio/mp4;codecs=mp4a.40.23', 'audio/mp4;codecs=mp4a.40.39', 'audio/aac'],
+  AudioEncoder.aacHe: ['audio/mp4;codecs=mp4a', 'audio/mp4;codecs=mp4a.40.29', 'audio/aac'],
 
   AudioEncoder.amrNb: ['audio/AMR'],
   AudioEncoder.amrWb: ['audio/AMR-WB'],


### PR DESCRIPTION
fixes #468

mp4a.40.23 is not actually working either on Chrome I just added it for completion sake.
mp4a.40.2 worked well on Chrome at least on MacOS.
Neither one seem to work on my installation of Firefox (maybe you have to install the codecs separately for that one).
