### PR TITLE
fix(linux): use PulseAudio recorder (parecord) instead of fmedia as library

### DIFF
--- a/record_linux/lib/record_linux.dart
+++ b/record_linux/lib/record_linux.dart
@@ -224,6 +224,7 @@ Future<void> start(
 	// 	alsa.card_name = "Blue Microphones"
 	// 	alsa.class = "generic"
 	// 	alsa.components = "USB046d:0ab7"
+  //  node.name = "alsa_input.usb-Generic_Blue_Microphones_LT_2201070607069D01069D_111000-00.analog-stereo"
   List<InputDevice> _parseInputDevices(List<String> output) {
     final devices = <InputDevice>[];
     String? currentDeviceId;

--- a/record_linux/lib/record_linux.dart
+++ b/record_linux/lib/record_linux.dart
@@ -236,8 +236,8 @@ Future<void> start(
             devices.add(InputDevice(id: currentDeviceId, label: currentDeviceName));
           }
         }
-        currentDeviceId = line.split('#')[1].trim();
-        currentDeviceName = null;
+      } else if (line.trim().startsWith('node.name')) {
+        currentDeviceId = line.split('=')[1].trim();
       } else if (line.trim().startsWith('Name:')) {
         currentDeviceName = line.split(':')[1].trim();
       } else if (line.trim().startsWith('Description:')) {

--- a/record_linux/lib/record_linux.dart
+++ b/record_linux/lib/record_linux.dart
@@ -107,6 +107,7 @@ Future<void> start(
     '--format=s16le',
     '--rate=${config.sampleRate}',
     '--channels=$numChannels',
+    '--latency-msec=100',
     if (config.device != null) '--device=${config.device!.id}',
     if (config.autoGain) '--property=auto_gain_control=1',
     if (config.echoCancel) '--property=echo_cancellation=1',
@@ -138,11 +139,6 @@ Future<void> start(
   @override
   Future<String?> stop(String recorderId) async {
     final path = _path;
-
-    if (_parecordProcess != null) {
-      // for some reason, parecord needs "2+ seconds" of record time to not cut the end of the audio
-      await Future.delayed(const Duration(milliseconds: 2000));
-    }
 
     _parecordProcess?.kill();
     _parecordProcess = null;


### PR DESCRIPTION
Hey all, looking to help with: https://github.com/llfbandit/record/issues/461

This is to use PulseAudio  `parecord` tool which is typically widely available in Linux Distributions, instead of the deprecated and abandoned fmedia project originally used in this library.

### Needs testing help!!

**Important:**
1. Seems to be working fine, tested with m4a, start, stop, pause, and resume.
2. Pause and Resume kills the process, and then starts another process under the same pipe. Needs testing, or if too risky, disable the support for pause and resume. It seems to work though.
3. Have not tested all codecs, testing help needed. Tested on Fedora Workstation.
4. Listing devices works, and seems to be working fine. Using `pactl` which is a standard library.
5. I am not sure if we still really need to have gstreamer1 and gstreamer1-plugins-base installed for this work, I have not removed those dependencies, if anyone can test, appreciated, but currently using PulseAudio is great for packaging into Flatpak or other standard distribution frameworks.
6. Only 1 and 2 channels are supported, but if you see the opportunity to remap channels and test it, maybe it works?

Best regards
Saif