### PR TITLE
improvement: Make amplitude broadcast

### DIFF
--- a/record/lib/src/record.dart
+++ b/record/lib/src/record.dart
@@ -226,7 +226,7 @@ class AudioRecorder {
 
   /// Request for amplitude at given [interval].
   Stream<Amplitude> onAmplitudeChanged(Duration interval) {
-    _amplitudeStreamCtrl ??= StreamController();
+    _amplitudeStreamCtrl ??= StreamController<Amplitude>.broadcast();
 
     _amplitudeTimerInterval = interval;
     _startAmplitudeTimer();


### PR DESCRIPTION
Making the amplitude stream a broadcast stream.

The main reason I think this is important to be improved is because if the developer is not calling `dispose` the `_amplitudeStreamCtrl` does not get disposed and can throw errors like `Bad State: Stream already listened to`

Also I think in general this is just a better way to do it.

