### PR TITLE
Adding support for startStream on Linux using Parecord stdout stream

### DIFF
--- a/record_platform_interface/lib/src/record_platform_interface.dart
+++ b/record_platform_interface/lib/src/record_platform_interface.dart
@@ -53,9 +53,7 @@ abstract class RecordPlatform extends PlatformInterface {
   /// When stopping the record, you must rely on stream close event to get
   /// full recorded data.
   Future<Stream<Uint8List>> startStream(
-          String recorderId, RecordConfig config) =>
-      throw UnimplementedError(
-          'startStream not implemented on the current platform.');
+          String recorderId, RecordConfig config);
 
   /// Stops recording session and release internal recorder resource.
   ///


### PR DESCRIPTION
This fork adds a dart implementation for capturing raw pcm16bit audio stream on linux. This implementation takes the stdout of the parecord process and returns the output as a Uint8List.

This fork additionally removes the ThrowUnimplemented error from the record_platform_interface, since all platforms are now supported.