### PR TITLE
fix(linux): Allow Streams broadcast to not lock a stream

### DIFF
--- a/record_linux/lib/record_linux.dart
+++ b/record_linux/lib/record_linux.dart
@@ -175,7 +175,7 @@ class RecordLinux extends RecordPlatform {
 
   @override
   Stream<RecordState> onStateChanged(String recorderId) {
-    _stateStreamCtrl ??= StreamController();
+    _stateStreamCtrl ??= StreamController<RecordState>.broadcast();
     return _stateStreamCtrl!.stream;
   }
 


### PR DESCRIPTION
Hello,

Not sure whether this came out recently due to another change, or if thus far I could not notice this before, but requesting access to the stream to list devices in **Linux** locks the stream and causes the library to fail, yielding: `Bad state: Stream has already been listened to.` after subsequent creation of `AudioRecorder` instances.

This PR fixes this so the stream is broadcasted per request and is not locked to a single call.

Without this PR, in the current state of the library, the recording in Linux only works for the first instantiation of AudioRecorder, but fails with subsequent ones (or multiple recorders or listeners!).

Best regards
Saif