### PR TITLE
fix: #509

### DIFF
--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/encoder/MediaCodecEncoder.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/encoder/MediaCodecEncoder.kt
@@ -155,16 +155,23 @@ class MediaCodecEncoder(
 
     private fun processOutputBuffer(codec: MediaCodec, index: Int, info: MediaCodec.BufferInfo) {
         try {
-            val outputBuffer = codec.getOutputBuffer(index)
-            if (outputBuffer != null && mContainer != null) {
-                if (mContainer!!.isStream()) {
-                    listener.onEncoderStream(
-                        mContainer!!.writeStream(mContainerTrack, outputBuffer, info)
-                    )
-                } else {
-                    mContainer!!.writeSampleData(mContainerTrack, outputBuffer, info)
+            val isCodecConfig = (info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0
+            if (isCodecConfig) {
+                // The CSD is passed to muxer in MediaFormat.
+                // So we ignore it.
+            } else if (info.size != 0) { // Should not write 0-sized buffer
+                val outputBuffer = codec.getOutputBuffer(index)
+                if (outputBuffer != null && mContainer != null) {
+                    if (mContainer!!.isStream()) {
+                        listener.onEncoderStream(
+                            mContainer!!.writeStream(mContainerTrack, outputBuffer, info)
+                        )
+                    } else {
+                        mContainer!!.writeSampleData(mContainerTrack, outputBuffer, info)
+                    }
                 }
             }
+
             codec.releaseOutputBuffer(index, false)
 
             if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {


### PR DESCRIPTION
issue causing aac/m4a files missing some metadata causing "Input buffer exhausted before END element found" error
related issue: #509 