### PR TITLE
Implement amplitude (dBFS) on Linux

### DIFF
--- a/record/README.md
+++ b/record/README.md
@@ -14,7 +14,7 @@ External dependencies:
 | Feature          | Android       | iOS             | web     | Windows    | macOS  | linux
 |------------------|---------------|-----------------|---------|------------|-------|-----------
 | pause/resume     | ✔️            |   ✔️             | ✔️     |      ✔️    | ✔️    |  ✔️
-| amplitude(dBFS)  | ✔️            |   ✔️             |  ✔️     |    ✔️     |  ✔️   |
+| amplitude(dBFS)  | ✔️            |   ✔️             |  ✔️     |    ✔️     |  ✔️   |  ✔️
 | permission check | ✔️            |   ✔️             |  ✔️    |            |  ✔️   |
 | num of channels  | ✔️            |   ✔️             |  ✔️    |    ✔️      |  ✔️   |  ✔️
 | device selection | ✔️ 1 / 2      | (auto BT/mic)    |  ✔️    |    ✔️      |  ✔️   |  ✔️


### PR DESCRIPTION
This PR adds amplitude support on Linux. I achieved this by using Claude Code using Opus 4 and letting it study the implementation on other platforms first. Also see [this issue](https://github.com/matthiasn/lotti/issues/2181#issuecomment-3094582922) in my project where I'm using it, which shows the prompts used, and the entire session log in the following comment. See how I'm using it in the project's [`pubspec.yaml`](https://github.com/matthiasn/lotti/blob/main/pubspec.yaml#L158) where I only need to override the `record_linux` dependency to use my fork with enabled amplitude on Linux.

Please let me know what needs to be changed for this PR to make it into the library. It would be super helpful to a) have this feature work and b) not to have to use a fork for it.

Resolves https://github.com/llfbandit/record/issues/524.