### PR TITLE
fix(Windows): Crashes on Flutter 3.35.1

### DIFF
--- a/record_windows/windows/event_stream_handler.h
+++ b/record_windows/windows/event_stream_handler.h
@@ -11,7 +11,10 @@ public:
     virtual ~EventStreamHandler() = default;
 
     void Success(std::unique_ptr<T> _data) {
-        if (m_sink.get()) m_sink.get()->Success(*_data.get());
+        auto sink = m_sink.get();
+        if (sink && _data) {
+            sink->Success(*_data.get());
+        }
     }
 
     void Error(const std::string& error_code, const std::string& error_message,
@@ -29,7 +32,7 @@ protected:
 
     std::unique_ptr<StreamHandlerError<T>> OnCancelInternal(
         const T* arguments) override {
-        m_sink.release();
+        m_sink.reset();
         return nullptr;
     }
 

--- a/record_windows/windows/record_readercallback.cpp
+++ b/record_windows/windows/record_readercallback.cpp
@@ -87,11 +87,13 @@ namespace record_windows
 
 			if (SUCCEEDED(hr))
 			{
-				// Read another sample
-				hr = m_pReader->ReadSample((DWORD)MF_SOURCE_READER_FIRST_AUDIO_STREAM,
-					0,
-					NULL, NULL, NULL, NULL
-				);
+				// Read another sample if reader still exists
+				if (m_pReader) {
+					hr = m_pReader->ReadSample((DWORD)MF_SOURCE_READER_FIRST_AUDIO_STREAM,
+						0,
+						NULL, NULL, NULL, NULL
+					);
+				}
 			}
 
 		}

--- a/record_windows/windows/record_windows_plugin.cpp
+++ b/record_windows/windows/record_windows_plugin.cpp
@@ -3,6 +3,7 @@
 #include <Mferror.h>
 #include "record_config.h"
 #include <flutter/event_stream_handler_functions.h>
+#include <mutex>
 
 using namespace flutter;
 
@@ -34,7 +35,7 @@ namespace record_windows {
 	}
 
 	// static, Register the plugin
-	void RecordWindowsPlugin::RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar) {
+		void RecordWindowsPlugin::RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar) {
 		auto plugin = std::make_unique<RecordWindowsPlugin>(
 			[registrar](auto delegate) {
 				return registrar->RegisterTopLevelWindowProcDelegate(delegate);
@@ -64,11 +65,18 @@ namespace record_windows {
 	std::queue<std::function<void()>> RecordWindowsPlugin::callbacks{};
 
 	// static
+	std::mutex RecordWindowsPlugin::callbacks_mutex{};
+
+	// static
 	FlutterRootWindowProvider RecordWindowsPlugin::get_root_window{};
 
 	// static
 	void RecordWindowsPlugin::RunOnMainThread(std::function<void()> callback) {
-		callbacks.push(callback);
+		// Lock only while pushing the callback, then release before posting the message.
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex);
+			callbacks.push(callback);
+		}
 		PostMessage(get_root_window(), WM_RUN_DELEGATE, 0, 0);
 	}
 
@@ -104,9 +112,18 @@ namespace record_windows {
 		std::optional<LRESULT> result;
 		switch (message) {
 		case WM_RUN_DELEGATE:
-			callbacks.front()();
-			callbacks.pop();
-			result = 0;
+			{
+				std::function<void()> cb;
+				{
+					std::lock_guard<std::mutex> lock(callbacks_mutex);
+					if (!callbacks.empty()) {
+						cb = std::move(callbacks.front());
+						callbacks.pop();
+					}
+				}
+				if (cb) cb();
+				result = 0;
+			}
 			break;
 		}
 		return result;
@@ -117,6 +134,9 @@ namespace record_windows {
 		const MethodCall<EncodableValue>& method_call,
 		std::unique_ptr<MethodResult<EncodableValue>> result
 	) {
+		{
+			std::string m = std::string("record_windows: HandleMethodCall: ") + method_call.method_name();
+		}
 		const auto args = method_call.arguments();
 		const auto* mapArgs = std::get_if<EncodableMap>(args);
 		if (!mapArgs) {
@@ -227,8 +247,17 @@ namespace record_windows {
 		}
 		else if (method_call.method_name().compare("dispose") == 0)
 		{
+			// Dispose recorder and schedule removal on the main thread so any
+			// callbacks already queued to run on the main thread (e.g. UpdateState)
+			// can run safely and observe the disposed state before the object is
+			// destroyed. Immediate erase would destroy the Recorder while lambdas
+			// referencing it may still be pending, causing access violations.
 			recorder->Dispose();
-			m_recorders.erase(recorderId);
+			RecordWindowsPlugin::RunOnMainThread([this, recorderId]() -> void {
+				m_recorders.erase(recorderId);
+				m_state_event_channels.erase(recorderId);
+				m_record_event_channels.erase(recorderId);
+			});
 
 			result->Success(EncodableValue());
 		}
@@ -330,12 +359,25 @@ namespace record_windows {
 		std::unique_ptr<StreamHandler<EncodableValue>> pRecordEventHandler{static_cast<StreamHandler<EncodableValue>*>(eventRecordHandler)};
 		eventRecordChannel->SetStreamHandler(std::move(pRecordEventHandler));
 
+			// Keep channels alive for the recorder lifetime and also keep shared
+			// ownership of handlers so Recorder's weak_ptr captures remain valid
+		// Keep channels alive for the recorder lifetime to ensure handlers
+		// (which Recorder stores raw pointers to) remain valid.
+		m_state_event_channels.insert(std::make_pair(recorderId, std::move(eventChannel)));
+		m_record_event_channels.insert(std::make_pair(recorderId, std::move(eventRecordChannel)));
+
 		Recorder* pRecorder = NULL;
 
 		HRESULT hr = Recorder::CreateInstance(eventHandler, eventRecordHandler, &pRecorder);
 		if (SUCCEEDED(hr))
 		{
 			m_recorders.insert(std::make_pair(recorderId, std::move(pRecorder)));
+			{
+				std::string msg = std::string("record_windows: Recorder created: ") + recorderId;
+			}
+			{
+				std::string msg = std::string("record_windows: Recorder created: ") + recorderId;
+			}
 		}
 
 		return hr;


### PR DESCRIPTION
Fixes: https://github.com/llfbandit/record/issues/535

- a use-after-free — callbacks posted to the platform/main thread invoked EventStreamHandler::Success after the EventStreamHandler (or its EventSink) had been destroyed. That dangling pointer caused the access violation in get()/Success.
- RunOnMainThread was being pushed from worker threads without robust synchronization and lambdas captured raw pointers, allowing ordering where destruction happened before callback execution.

In the example there are issues with Audio Players reporting errors, but this was out of scope.

**NOTE:** This PR has been implemented with AI-assisted copilot. I have however tested the fix manually, built, and ran the examples myself, as I was guided with it to implement the changes.

Feel free to adjust as desired. I cannot explain why this breaks with Flutter 3.35.1 however.

Best regards