### PR TITLE
Fix audio settings when recording to file on macOS

### DIFF
--- a/record_macos/macos/record_macos/Sources/record_macos/delegate/RecorderFileDelegate.swift
+++ b/record_macos/macos/record_macos/Sources/record_macos/delegate/RecorderFileDelegate.swift
@@ -40,10 +40,12 @@ class RecorderFileDelegate: NSObject, AudioRecordingFileDelegate, AVCaptureFileO
     // Add input device
     audioSession.addInput(dev)
     // Add output
-    let outputSettings = try getOutputSettings(config: config)
     let audioOutput = AVCaptureAudioFileOutput()
-    audioOutput.audioSettings = outputSettings
     audioSession.addOutput(audioOutput)
+
+    // Set audioSettings *after* adding to session, otherwise it is ignored
+    let outputSettings = try getOutputSettings(config: config)
+    audioOutput.audioSettings = outputSettings
     
     audioSession.commitConfiguration()
     

--- a/record_macos/macos/record_macos/Sources/record_macos/extension/RecorderFormatExtension.swift
+++ b/record_macos/macos/record_macos/Sources/record_macos/extension/RecorderFormatExtension.swift
@@ -41,7 +41,7 @@ extension AudioRecordingDelegate {
       ]
     case AudioEncoder.aacEld.rawValue:
       settings = [
-        AVFormatIDKey : kAudioFormatMPEG4AAC_ELD_V2,
+        AVFormatIDKey : kAudioFormatMPEG4AAC_ELD,
         AVEncoderBitRateKey: config.bitRate,
         AVSampleRateKey: config.sampleRate,
         AVNumberOfChannelsKey: config.numChannels,

--- a/record_macos/macos/record_macos/Sources/record_macos/extension/RecorderFormatExtension.swift
+++ b/record_macos/macos/record_macos/Sources/record_macos/extension/RecorderFormatExtension.swift
@@ -100,7 +100,6 @@ extension AudioRecordingDelegate {
         AVLinearPCMIsNonInterleaved: false,
         AVSampleRateKey: config.sampleRate,
         AVNumberOfChannelsKey: config.numChannels,
-        AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
       ]
       keepSampleRate = true
     case AudioEncoder.wav.rawValue:
@@ -112,7 +111,6 @@ extension AudioRecordingDelegate {
         AVLinearPCMIsNonInterleaved: false,
         AVSampleRateKey: config.sampleRate,
         AVNumberOfChannelsKey: config.numChannels,
-        AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
       ]
       keepSampleRate = true
     default:


### PR DESCRIPTION
* Set audioSettings on the AVCaptureAudioFileOutput *after* adding to session
* Remove AVEncoderAudioQualityKey which is disallowed for kAudioFormatLinearPCM
* When using `AudioEncoder.aacEld`, switch to `kAudioFormatMPEG4AAC_ELD` instead of `kAudioFormatMPEG4AAC_ELD_V2`, as V2 was giving buggy hang behavior when running the example app on macOS

Fixes #280, #397

-----

Tested using the steps outlined in #397 with `AudioEncoder.pcm16bits`. Also checked to make sure no crashes with `aacLc`, `aacEld`, `flac`, `wav`.

Also tested that changing `sampleRate` passed to `RecordConfig` successfully changes the rate shown in ffprobe output.

During testing had to update `example/pubspec.yaml`:

```yaml
record:
  path: ../
```

And `record/pubspec.yaml`:

```yaml
record_macos:
  path: ../record_macos/
```