### PR TITLE
fix(ios): Clamp to supported sample rates for Opus on iOS

### DIFF
--- a/record_ios/ios/record_ios/Sources/record_ios/Recorder.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/Recorder.swift
@@ -160,7 +160,7 @@ class Recorder {
   func isEncoderSupported(_ encoder: String) -> Bool {
     switch(encoder) {
     case AudioEncoder.aacLc.rawValue,
-      AudioEncoder.aacEld.rawValue, /*"aacHe", "amrNb", "amrWb", "opus",*/
+      AudioEncoder.aacEld.rawValue, /*"aacHe", "amrNb", "amrWb",*/
       AudioEncoder.flac.rawValue,
       AudioEncoder.opus.rawValue,
       AudioEncoder.pcm16bits.rawValue,

--- a/record_ios/ios/record_ios/Sources/record_ios/extension/RecorderFormatExtension.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/extension/RecorderFormatExtension.swift
@@ -76,10 +76,11 @@ extension AudioRecordingDelegate {
         AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
       ]
     case AudioEncoder.opus.rawValue:
+      let opusSampleRates = [8000, 12000, 16000, 24000, 48000] as [NSNumber]
       settings = [
         AVFormatIDKey : kAudioFormatOpus,
         AVEncoderBitRateKey: config.bitRate,
-        AVSampleRateKey: config.sampleRate,
+        AVSampleRateKey: nearestValue(values: opusSampleRates, value: config.sampleRate as NSNumber, key: "opus sample rate"),
         AVNumberOfChannelsKey: config.numChannels,
         AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
       ]


### PR DESCRIPTION
Sample rates from this table: https://datatracker.ietf.org/doc/html/rfc6716#section-2

Unfortunately there's not a good way to query `AVAudioConverter.availableEncodeSampleRates` because as far as I can tell, it requires a valid sampleRate to construct the converter in the first place (and cannot be nil). So I had to hardcode the known Opus sample rates instead.

Closes #560 