### PR TITLE
feat: Add `request` parameter to `hasPermission()`

### DIFF
--- a/record/CHANGELOG.md
+++ b/record/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Upcoming
+* feat: Add `request` parameter to `hasPermission()` method to check permission status without requesting.
+
 ## 6.1.2
 * chore: Updated transitive dependencies.
 * chore: Update README.md & bg_recording.md.

--- a/record/README.md
+++ b/record/README.md
@@ -74,6 +74,12 @@ if (await record.hasPermission()) {
   final stream = await record.startStream(const RecordConfig(encoder: AudioEncoder.pcm16bits));
 }
 
+// Check permission status without requesting (useful for UI state)
+final hasPermission = await record.hasPermission(request: false);
+if (!hasPermission) {
+  // Show permission request UI, then call hasPermission() to request
+}
+
 // Stop recording...
 final path = await record.stop();
 // ... or cancel it (and implicitly remove file/blob).

--- a/record/lib/src/record.dart
+++ b/record/lib/src/record.dart
@@ -130,9 +130,19 @@ class AudioRecorder {
     return _safeCall(() => _platform.isPaused(_recorderId));
   }
 
-  /// Checks and requests for audio record permission.
-  Future<bool> hasPermission() {
-    return _safeCall(() => _platform.hasPermission(_recorderId));
+  /// Checks and optionally requests for audio record permission.
+  ///
+  /// The [request] parameter controls whether to request permission if not
+  /// already granted. Defaults to `true`.
+  Future<bool> hasPermission({
+    bool request = true,
+  }) {
+    return _safeCall(
+      () => _platform.hasPermission(
+        _recorderId,
+        request: request,
+      ),
+    );
   }
 
   /// Lists capture/input devices available on the platform.

--- a/record_android/CHANGELOG.md
+++ b/record_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Upcoming
+* feat: Add `request` parameter to `hasPermission()` method to check permission status without requesting.
+
 ## 1.4.5
 * fix: WAVE header for files larger than 2GB.
 

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
@@ -80,7 +80,10 @@ class MethodCallHandlerImpl(
       "isPaused" -> recorder.isPaused(result)
       "isRecording" -> recorder.isRecording(result)
       "cancel" -> recorder.cancel(result)
-      "hasPermission" -> permissionManager.hasPermission(result::success)
+      "hasPermission" -> {
+        val request = call.argument<Boolean>("request") ?: true
+        permissionManager.hasPermission(request, result::success)
+      }
       "getAmplitude" -> recorder.getAmplitude(result)
       "listInputDevices" -> result.success(DeviceUtils.listInputDevicesAsMap(appContext))
 

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/permission/PermissionManager.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/permission/PermissionManager.kt
@@ -29,19 +29,20 @@ class PermissionManager : RequestPermissionsResultListener {
     return false
   }
 
-  fun hasPermission(resultCallback: PermissionResultCallback) {
+  fun hasPermission(request: Boolean = true, resultCallback: PermissionResultCallback) {
     if (activity == null) {
       resultCallback.onResult(false)
       return
     }
-    if (!isPermissionGranted(activity!!)) {
+    val isGranted = isPermissionGranted(activity!!)
+    if (!isGranted && request) {
       this.resultCallback = resultCallback
       ActivityCompat.requestPermissions(
         activity!!, arrayOf(Manifest.permission.RECORD_AUDIO),
         RECORD_AUDIO_REQUEST_CODE
       )
     } else {
-      resultCallback.onResult(true)
+      resultCallback.onResult(isGranted)
     }
   }
 

--- a/record_ios/CHANGELOG.md
+++ b/record_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Upcoming
+* feat: Add `request` parameter to `hasPermission()` method to check permission status without requesting.
+
 ## 1.1.5
 * fix: Clamp to supported sample rates for Opus.
 

--- a/record_ios/ios/record_ios/Sources/record_ios/RecordIosPlugin.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/RecordIosPlugin.swift
@@ -124,7 +124,8 @@ public class RecordIosPlugin: NSObject, FlutterPlugin {
       let isRecording = recorder.isRecording()
       result(isRecording)
     case "hasPermission":
-      hasPermission(result)
+      let request = args["request"] as? Bool ?? true
+      hasPermission(request: request, result)
     case "getAmplitude":
       let amp = recorder.getAmplitude()
       result(amp)
@@ -188,16 +189,20 @@ public class RecordIosPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func hasPermission(_ result: @escaping FlutterResult) {
+  private func hasPermission(request: Bool, _ result: @escaping FlutterResult) {
     switch AVCaptureDevice.authorizationStatus(for: .audio) {
     case .authorized:
       result(true)
       break
     case .notDetermined:
-      AVCaptureDevice.requestAccess(for: .audio) { allowed in
-        DispatchQueue.main.async {
-          result(allowed)
+      if request {
+        AVCaptureDevice.requestAccess(for: .audio) { allowed in
+          DispatchQueue.main.async {
+            result(allowed)
+          }
         }
+      } else {
+        result(false)
       }
       break
     default:

--- a/record_linux/lib/record_linux.dart
+++ b/record_linux/lib/record_linux.dart
@@ -42,7 +42,7 @@ class RecordLinux extends RecordPlatform {
   }
 
   @override
-  Future<bool> hasPermission(String recorderId) {
+  Future<bool> hasPermission(String recorderId, {bool request = true}) {
     return Future.value(true);
   }
 

--- a/record_macos/CHANGELOG.md
+++ b/record_macos/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Upcoming
+* feat: Add `request` parameter to `hasPermission()` method to check permission status without requesting.
+
 ## 1.1.2
 * fix: Use kAudioFormatMPEG4AAC_ELD instead of kAudioFormatMPEG4AAC_ELD_V2 for improved compatibility.
 * fix: Fix applying audio settings when saving file on macOS (for PCM/WAV mostly)

--- a/record_macos/macos/record_macos/Sources/record_macos/RecordMacOsPlugin.swift
+++ b/record_macos/macos/record_macos/Sources/record_macos/RecordMacOsPlugin.swift
@@ -118,7 +118,8 @@ public class RecordMacOsPlugin: NSObject, FlutterPlugin {
       let isRecording = recorder.isRecording()
       result(isRecording)
     case "hasPermission":
-      hasPermission(result)
+      let request = args["request"] as? Bool ?? true
+      hasPermission(request: request, result)
     case "getAmplitude":
       let amp = recorder.getAmplitude()
       result(amp)
@@ -146,16 +147,20 @@ public class RecordMacOsPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func hasPermission(_ result: @escaping FlutterResult) {
+  private func hasPermission(request: Bool, _ result: @escaping FlutterResult) {
     switch AVCaptureDevice.authorizationStatus(for: .audio) {
     case .authorized:
       result(true)
       break
     case .notDetermined:
-      AVCaptureDevice.requestAccess(for: .audio) { allowed in
-        DispatchQueue.main.async {
-          result(allowed)
+      if request {
+        AVCaptureDevice.requestAccess(for: .audio) { allowed in
+          DispatchQueue.main.async {
+            result(allowed)
+          }
         }
+      } else {
+        result(false)
       }
       break
     default:

--- a/record_platform_interface/CHANGELOG.md
+++ b/record_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Upcoming
+* feat: Add `request` parameter to `hasPermission()` method to check permission status without requesting.
+
 ## 1.4.0
 * feat: Add AudioInterruptionMode to `RecordConfig`.
 * feat: Add stream buffer size option.

--- a/record_platform_interface/lib/src/record_method_channel_mixin.dart
+++ b/record_platform_interface/lib/src/record_method_channel_mixin.dart
@@ -19,10 +19,10 @@ mixin RecordMethodChannel implements RecordMethodChannelPlatformInterface {
   }
 
   @override
-  Future<bool> hasPermission(String recorderId) async {
+  Future<bool> hasPermission(String recorderId, {bool request = true}) async {
     final result = await _methodChannel.invokeMethod<bool>(
       'hasPermission',
-      {'recorderId': recorderId},
+      {'recorderId': recorderId, 'request': request},
     );
     return result ?? false;
   }

--- a/record_platform_interface/lib/src/record_platform_interface.dart
+++ b/record_platform_interface/lib/src/record_platform_interface.dart
@@ -67,8 +67,11 @@ abstract class RecordMethodChannelPlatformInterface {
   /// Checks if recording session is paused.
   Future<bool> isPaused(String recorderId);
 
-  /// Checks and requests for audio record permission.
-  Future<bool> hasPermission(String recorderId);
+  /// Checks and optionally requests for audio record permission.
+  ///
+  /// The [request] parameter controls whether to request permission if not
+  /// already granted. Defaults to `true`.
+  Future<bool> hasPermission(String recorderId, {bool request = true});
 
   /// Dispose the recorder
   Future<void> dispose(String recorderId);

--- a/record_web/CHANGELOG.md
+++ b/record_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Upcoming
+* feat: Add `request` parameter to `hasPermission()` method to check permission status without requesting.
+
 ## 1.2.2
 * fix: WAVE header for big files (RAM pressure & truncated integer).
 

--- a/record_web/lib/record_web.dart
+++ b/record_web/lib/record_web.dart
@@ -29,8 +29,8 @@ class RecordPluginWebWrapper extends RecordPlatform {
   }
 
   @override
-  Future<bool> hasPermission(String recorderId) {
-    return _getRecorder(recorderId).hasPermission();
+  Future<bool> hasPermission(String recorderId, {bool request = true}) {
+    return _getRecorder(recorderId).hasPermission(request: request);
   }
 
   @override

--- a/record_web/lib/recorder/recorder.dart
+++ b/record_web/lib/recorder/recorder.dart
@@ -16,7 +16,7 @@ class Recorder {
   RecorderDelegate? _delegate;
   StreamController<RecordState>? _stateStreamCtrl;
 
-  Future<bool> hasPermission() async {
+  Future<bool> _requestPermission() async {
     final mediaDevices = web.window.navigator.mediaDevices;
 
     try {
@@ -33,6 +33,18 @@ class Recorder {
     } catch (_) {
       return false;
     }
+  }
+
+  Future<bool> hasPermission({bool request = true}) async {
+    final permissions = web.window.navigator.permissions;
+    final permissionStatus = await permissions
+        .query(_PermissionDescriptor(name: 'microphone'))
+        .toDart;
+
+    final isGranted = permissionStatus.state == 'granted';
+    if (!isGranted && request) return _requestPermission();
+
+    return isGranted;
   }
 
   Future<List<InputDevice>> listInputDevices() async {
@@ -190,4 +202,12 @@ class Recorder {
       ctrl.add(state);
     }
   }
+}
+
+// copied from https://github.com/dart-lang/web/commit/7604578eb538c471d438608673c037121d95dba5#diff-6f4c7956b6e25b547b16fc561e54d5e7d520d2c79a59ace4438c60913cc2b1a2L35-L40
+extension type _PermissionDescriptor._(JSObject _) implements JSObject {
+  external factory _PermissionDescriptor({required String name});
+
+  external set name(String value);
+  external String get name;
 }


### PR DESCRIPTION
Fixes: #543

Adds an optional `request` parameter to the `hasPermission()` method. This allows checking for the audio recording permission status without triggering the permission request dialog.

This change is implemented across the platform interface and all supported platforms (Android, iOS, macOS, Web, and Linux).