### PR TITLE
Refactor `convertBytesToInt16` and fix offset handling for Uint8List views

### DIFF
--- a/record/lib/src/record.dart
+++ b/record/lib/src/record.dart
@@ -263,17 +263,22 @@ class AudioRecorder {
     _recordStreamCtrl = null;
   }
 
-  /// Utility method to get PCM data as signed 16 bits integers.
-  List<int> convertBytesToInt16(Uint8List bytes, [endian = Endian.little]) {
-    final values = <int>[];
-
-    final data = ByteData.view(bytes.buffer);
-
-    for (var i = 0; i < bytes.length; i += 2) {
-      int short = data.getInt16(i, endian);
-      values.add(short);
+  /// Converts a [Uint8List] of bytes to a [List<int>] of signed 16-bit integers.
+  /// 
+  /// [endian] specifies the byte order (default: [Endian.little]).
+  /// Throws [ArgumentError] if `bytes.length` is not even.
+  List<int> convertBytesToInt16(Uint8List bytes, [Endian endian = Endian.little]) {
+    if (bytes.length % 2 != 0) {
+      throw ArgumentError('Input byte length must be even.');
     }
 
+    // Ensure correct byte offset and length are used
+    final byteData = ByteData.sublistView(bytes);
+    final values = List<int>.filled(bytes.length ~/ 2, 0);
+
+    for (var i = 0; i < values.length; i++) {
+      values[i] = byteData.getInt16(i * 2, endian);
+    }
     return values;
   }
 


### PR DESCRIPTION
This PR refactors the `convertBytesToInt16` method for clarity and adds proper handling of `Uint8List.offsetInBytes`.  

It fixes the issue where `convertBytesToInt16` ignored the offset of `Uint8List` views, causing incorrect PCM16 samples when the input buffer was a slice/view of a larger buffer: [Issue #575](https://github.com/llfbandit/record/issues/575#issuecomment-3748849995).

**Changes:**

Before:

```dart
List<int> convertBytesToInt16(Uint8List bytes, [endian = Endian.little]) {
  final values = <int>[];
  final data = ByteData.view(bytes.buffer);

  for (var i = 0; i < bytes.length; i += 2) {
    values.add(data.getInt16(i, endian));
  }

  return values;
}
````

After:

```dart
/// Converts a [Uint8List] of bytes to a [List<int>] of signed 16-bit integers.
/// 
/// [endian] specifies the byte order (default: [Endian.little]).
/// Throws [ArgumentError] if `bytes.length` is not even.
List<int> convertBytesToInt16(Uint8List bytes, [Endian endian = Endian.little]) {
  if (bytes.length % 2 != 0) {
    throw ArgumentError('Input byte length must be even.');
  }

  // Ensure correct byte offset and length are used
  final byteData = ByteData.sublistView(bytes);
  final values = List<int>.filled(bytes.length ~/ 2, 0);

  for (var i = 0; i < values.length; i++) {
    values[i] = byteData.getInt16(i * 2, endian);
  }

  return values;
}

```

**Benefits / Impact:**

* Correctly handles `Uint8List` views with non-zero offsets
* Prevents misaligned PCM16 sample values in streaming audio
* Backwards compatible for full buffers
* Improves clarity and avoids dynamic list growth for performance

**Minimal test example:**

```dart
final bigBuffer = Uint8List.fromList([
  0x01, 0x00, // 1
  0x02, 0x00, // 2
  0x03, 0x00, // 3
  0x04, 0x00, // 4
]);

final view = Uint8List.view(bigBuffer.buffer, 4, 4);

final result = convertBytesToInt16(view);
assert(result[0] == 3 && result[1] == 4); // ✅ passes
```

This fixes audio streaming issues where only a portion of a larger buffer is passed to `convertBytesToInt16`.


