### PR TITLE
[Linux] Overriding the locale for the pactl command

### DIFF
--- a/record_linux/lib/record_linux.dart
+++ b/record_linux/lib/record_linux.dart
@@ -272,7 +272,8 @@ class RecordLinux extends RecordPlatform {
     VoidCallback? onStarted,
     bool consumeOutput = true,
   }) async {
-    final process = await Process.start('pactl', arguments);
+    // Force LC_ALL=C for pactl output to ensure consistent parsing
+    final process = await Process.start('pactl', arguments, environment: {"LC_ALL": "C"});
 
     if (onStarted != null) {
       onStarted();


### PR DESCRIPTION
pactl enforce LC_ALL=C for command output

Overrides the locale to LC_ALL=C to prevent localization issues. 
This ensures that the script parses pactl output correctly regardless 
of the system's default language.