### PR TITLE
fix(macos): Preserve stereo streaming

### DIFF
--- a/record_macos/macos/record_macos/Sources/record_macos/InputHelper.swift
+++ b/record_macos/macos/record_macos/Sources/record_macos/InputHelper.swift
@@ -13,7 +13,7 @@ func listInputs() throws -> [Device] {
 
 func listInputDevices() -> [AVCaptureDevice] {
   let discoverySession = AVCaptureDevice.DiscoverySession(
-    deviceTypes: [.builtInMicrophone],
+    deviceTypes: [.builtInMicrophone, .externalUnknown],
     mediaType: .audio, position: .unspecified
   )
   


### PR DESCRIPTION
Keep stream conversion from collapsing multi-channel input to mono, use non-interleaved PCM to match channel-data access, and include external audio devices in discovery