### PR TITLE
refactor(windows): make start and startStream async

### DIFF
--- a/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/methodcall/MethodCallHandlerImpl.kt
@@ -1,6 +1,8 @@
 package com.llfbandit.record.methodcall
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.llfbandit.record.permission.PermissionManager
 import com.llfbandit.record.record.RecordConfig
 import com.llfbandit.record.record.device.DeviceUtils
@@ -12,6 +14,8 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import java.io.IOException
 import java.util.Objects
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 class MethodCallHandlerImpl(
   private val permissionManager: PermissionManager,
@@ -19,6 +23,8 @@ class MethodCallHandlerImpl(
   private val appContext: Context
 ) : MethodCallHandler {
   private val recorders = ConcurrentHashMap<String, RecorderWrapper>()
+  private val uiThreadHandler = Handler(Looper.getMainLooper())
+  private val startExecutor: ExecutorService = Executors.newSingleThreadExecutor()
 
   fun dispose() {
     for (entry in recorders.entries) {
@@ -26,6 +32,7 @@ class MethodCallHandlerImpl(
     }
 
     recorders.clear()
+    startExecutor.shutdownNow()
   }
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -56,21 +63,29 @@ class MethodCallHandlerImpl(
     }
 
     when (call.method) {
-      "start" -> {
+      "start" -> startExecutor.execute {
         try {
           val config = RecordConfig.fromMap(call, appContext)
-          recorder.startRecordingToFile(config, result)
+          recorder.startRecordingToFile(config, MainThreadResult(result))
         } catch (e: IOException) {
-          result.error("record", "Cannot create recording configuration.", e.message)
+          MainThreadResult(result).error(
+            "record",
+            "Cannot create recording configuration.",
+            e.message
+          )
         }
       }
 
-      "startStream" -> {
+      "startStream" -> startExecutor.execute {
         try {
           val config = RecordConfig.fromMap(call, appContext)
-          recorder.startRecordingToStream(config, result)
+          recorder.startRecordingToStream(config, MainThreadResult(result))
         } catch (e: IOException) {
-          result.error("record", "Cannot create recording configuration.", e.message)
+          MainThreadResult(result).error(
+            "record",
+            "Cannot create recording configuration.",
+            e.message
+          )
         }
       }
 
@@ -101,6 +116,22 @@ class MethodCallHandlerImpl(
       }
 
       else -> result.notImplemented()
+    }
+  }
+
+  private inner class MainThreadResult(
+    private val delegate: MethodChannel.Result
+  ) : MethodChannel.Result {
+    override fun success(result: Any?) {
+      uiThreadHandler.post { delegate.success(result) }
+    }
+
+    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+      uiThreadHandler.post { delegate.error(errorCode, errorMessage, errorDetails) }
+    }
+
+    override fun notImplemented() {
+      uiThreadHandler.post { delegate.notImplemented() }
     }
   }
 

--- a/record_ios/ios/record_ios/Sources/record_ios/RecordIosPlugin.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/RecordIosPlugin.swift
@@ -74,27 +74,47 @@ public class RecordIosPlugin: NSObject, FlutterPlugin {
       guard let config = getConfig(args, result: result) else {
         return
       }
-      
-      do {
-        try recorder.start(config: config, path: path)
-        result(nil)
-      } catch RecorderError.error(let message, let details) {
-        result(FlutterError(code: "record", message: message, details: details))
-      } catch {
-        result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+
+      // Avoid blocking Flutter platform thread
+      DispatchQueue.global(qos: .userInitiated).async {
+        do {
+          try recorder.start(config: config, path: path)
+
+          DispatchQueue.main.async {
+            result(nil)
+          }
+        } catch RecorderError.error(let message, let details) {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: message, details: details))
+          }
+        } catch {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+          }
+        }
       }
     case "startStream":
       guard let config = getConfig(args, result: result) else {
         return
       }
 
-      do {
-        try recorder.startStream(config: config)
-        result(nil)
-      } catch RecorderError.error(let message, let details) {
-        result(FlutterError(code: "record", message: message, details: details))
-      } catch {
-        result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+      // Avoid blocking Flutter platform thread
+      DispatchQueue.global(qos: .userInitiated).async {
+        do {
+          try recorder.startStream(config: config)
+
+          DispatchQueue.main.async {
+            result(nil)
+          }
+        } catch RecorderError.error(let message, let details) {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: message, details: details))
+          }
+        } catch {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+          }
+        }
       }
     case "stop":
       recorder.stop { path in

--- a/record_macos/macos/record_macos/Sources/record_macos/RecordMacOsPlugin.swift
+++ b/record_macos/macos/record_macos/Sources/record_macos/RecordMacOsPlugin.swift
@@ -64,31 +64,56 @@ public class RecordMacOsPlugin: NSObject, FlutterPlugin {
         result(FlutterError(code: "record", message: "Call missing mandatory parameter path.", details: nil))
         return
       }
-      
+
       guard let config = getConfig(args, result: result) else {
         return
       }
-      
-      do {
-        try recorder.start(config: config, path: path)
-        result(nil)
-      } catch RecorderError.error(let message, let details) {
-        result(FlutterError(code: "record", message: message, details: details))
-      } catch {
-        result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+
+      // Avoid blocking Flutter platform thread
+      DispatchQueue.global(qos: .userInitiated).async {
+
+        do {
+          try recorder.start(config: config, path: path)
+
+          DispatchQueue.main.async {
+            result(nil)
+          }
+
+        } catch RecorderError.error(let message, let details) {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: message, details: details))
+          }
+
+        } catch {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+          }
+        }
       }
     case "startStream":
       guard let config = getConfig(args, result: result) else {
         return
       }
 
-      do {
-        try recorder.startStream(config: config)
-        result(nil)
-      } catch RecorderError.error(let message, let details) {
-        result(FlutterError(code: "record", message: message, details: details))
-      } catch {
-        result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+      DispatchQueue.global(qos: .userInitiated).async {
+
+        do {
+          try recorder.startStream(config: config)
+
+          DispatchQueue.main.async {
+            result(nil)
+          }
+
+        } catch RecorderError.error(let message, let details) {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: message, details: details))
+          }
+
+        } catch {
+          DispatchQueue.main.async {
+            result(FlutterError(code: "record", message: error.localizedDescription, details: nil))
+          }
+        }
       }
     case "stop":
       recorder.stop { path in

--- a/record_windows/windows/record_windows_plugin.cpp
+++ b/record_windows/windows/record_windows_plugin.cpp
@@ -4,6 +4,7 @@
 #include "record_config.h"
 #include <flutter/event_stream_handler_functions.h>
 #include <mutex>
+#include <thread>
 
 using namespace flutter;
 
@@ -202,19 +203,36 @@ namespace record_windows {
 			std::string path;
 			GetValueFromEncodableMap(mapArgs, "path", path);
 
-			HRESULT hr = recorder->Start(std::move(config), Utf16FromUtf8(path));
+			auto* rawResult = result.release();
+			auto recordingPath = Utf16FromUtf8(path);
 
-			if (SUCCEEDED(hr)) { result->Success(EncodableValue()); }
-			else { ErrorFromHR(hr, *result); }
+			std::thread([this, recorder, config = std::move(config), recordingPath = std::move(recordingPath), rawResult]() mutable {
+				HRESULT hr = recorder->Start(std::move(config), recordingPath);
+
+				RecordWindowsPlugin::RunOnMainThread([hr, rawResult]() mutable {
+					std::unique_ptr<MethodResult<EncodableValue>> resultPtr(rawResult);
+
+					if (SUCCEEDED(hr)) { resultPtr->Success(EncodableValue()); }
+					else { ErrorFromHR(hr, *resultPtr); }
+				});
+			}).detach();
 		}
 		else if (method_call.method_name().compare("startStream") == 0)
 		{
 			auto config = InitRecordConfig(mapArgs);
 
-			HRESULT hr = recorder->StartStream(std::move(config));
+			auto* rawResult = result.release();
 
-			if (SUCCEEDED(hr)) { result->Success(EncodableValue()); }
-			else { ErrorFromHR(hr, *result); }
+			std::thread([this, recorder, config = std::move(config), rawResult]() mutable {
+				HRESULT hr = recorder->StartStream(std::move(config));
+
+				RecordWindowsPlugin::RunOnMainThread([hr, rawResult]() mutable {
+					std::unique_ptr<MethodResult<EncodableValue>> resultPtr(rawResult);
+
+					if (SUCCEEDED(hr)) { resultPtr->Success(EncodableValue()); }
+					else { ErrorFromHR(hr, *resultPtr); }
+				});
+			}).detach();
 		}
 		else if (method_call.method_name().compare("stop") == 0)
 		{
@@ -366,19 +384,19 @@ namespace record_windows {
 		HRESULT hr = Recorder::CreateInstance(eventHandler, eventRecordHandler, &pRecorder);
 		if (SUCCEEDED(hr))
 		{
-			m_recorders.insert(std::make_pair(recorderId, std::move(pRecorder)));
+			m_recorders.insert(std::make_pair(recorderId, std::shared_ptr<Recorder>(pRecorder)));
 		}
 
 		return hr;
 	}
 
-	Recorder* RecordWindowsPlugin::GetRecorder(std::string recorderId)
+	std::shared_ptr<Recorder> RecordWindowsPlugin::GetRecorder(std::string recorderId)
 	{
 		auto searchedRecorder = m_recorders.find(recorderId);
 		if (searchedRecorder == m_recorders.end()) {
 			return nullptr;
 		}
-		return searchedRecorder->second.get();
+		return searchedRecorder->second;
 	}
 
 	HRESULT RecordWindowsPlugin::ListInputDevices(MethodResult<EncodableValue>& result)

--- a/record_windows/windows/record_windows_plugin.h
+++ b/record_windows/windows/record_windows_plugin.h
@@ -10,6 +10,7 @@
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
 #include <memory>
+#include <functional>
 #include <mutex>
 
 #include <windows.h>
@@ -68,12 +69,12 @@ namespace record_windows {
 			std::unique_ptr<MethodResult<EncodableValue>> result);
 
 		HRESULT CreateRecorder(std::string recorderId);
-		Recorder* GetRecorder(std::string recorderId);
+		std::shared_ptr<Recorder> GetRecorder(std::string recorderId);
 		HRESULT ListInputDevices(MethodResult<EncodableValue>& result);
 
 		std::unique_ptr<RecordConfig> InitRecordConfig(const EncodableMap* args);
 
-		std::map<std::string, std::unique_ptr<Recorder>> m_recorders{};
+		std::map<std::string, std::shared_ptr<Recorder>> m_recorders{};
 
 		// Keep event channels alive for each recorder so StreamHandler pointers
 		// stored by Recorder remain valid while the recorder exists.


### PR DESCRIPTION
Refactor start and startStream methods for async handling

## Problem

Calling startStream blocks the Flutter UI thread on macOS.

In Flutter DevTools:

Platform Channel send com.llfbandit.record/messages#startStream ~178ms

This happens because recorder.startStream() runs on the main thread and performs AVAudioEngine initialization.

## Solution

Run startStream on a background queue and return result on the main thread.

## Result

Platform channel blocking time reduced from ~178ms → ~2ms.

No functional changes, only thread handling improvement.