### PR TITLE
fix(ios): correct AVAudioPCMBuffer frame capacity calculation on IOS

### DIFF
--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -205,7 +205,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     }
     
     // Determine frame capacity
-    let capacity = (UInt32(dstFormat.sampleRate) * dstFormat.channelCount * buffer.frameLength) / (UInt32(buffer.format.sampleRate) * buffer.format.channelCount)
+    let capacity = AVAudioFrameCount(Double(buffer.frameLength) * dstFormat.sampleRate / buffer.format.sampleRate)
     
     // Destination buffer
     guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: capacity) else {


### PR DESCRIPTION
## Description
This MR corrects a bug in how `AVAudioPCMBuffer` frame capacity is calculated during audio conversion in iOS, bringing the implementation in line with the already correct logic used in macOS.

### The Issue
Previously, the iOS destination buffer's `frameCapacity` calculation incorrectly factored in the `channelCount` of both the source and destination formats.

Because an audio "frame" represents a slice of time across all channels simultaneously, the number of frames during conversion depends only on the ratio of the sample rates. Factoring in channelCount leads to an incorrect capacity specifically when the source and destination have a different number of channels.

The visible effect of this bug was that audio was cropped when reducing the number of channels (e.g., stereo to mono), and extended when increasing the number of channels (e.g., mono to stereo). The output buffer was either under-allocated (truncating the audio) or over-allocated (resulting in extra duration or blank space).

### Impact

- Resolves cropped audio when recording with fewer channels than the source, and extended audio when recording with more channels on iOS.
- Ensures the correct buffer size is allocated for the downstream processing pipeline.
- Aligns iOS conversion logic with the existing, correct macOS implementation.