### PR TITLE
fix(iOS): recover stream recorder from audio route changes

### DIFF
--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -129,7 +129,8 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
       return
     }
     switch reason {
-    case .newDeviceAvailable, .oldDeviceUnavailable, .routeConfigurationChange:
+    case .newDeviceAvailable, .oldDeviceUnavailable, .routeConfigurationChange, .override:
+      print("[record_ios] Route change recovery triggered (reason=\(reason.rawValue))")
       scheduleRouteRecovery()
     default:
       break

--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -23,6 +23,11 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
   private var m_routeChangeObserver: NSObjectProtocol?
   private var m_shouldBeRunning: Bool = false
   private let m_recoveryQueue = DispatchQueue(label: "com.llfbandit.record.recovery")
+  // Cached UID of the currently-routed input. Used to distinguish genuine
+  // input-route changes from output-only .override events (e.g. user toggles
+  // speakerphone in Control Center), so we don't rebuild the tap for an
+  // override that didn't actually change the input.
+  private var m_currentInputUID: String?
 
   init(manageAudioSession: Bool, onRecord: @escaping () -> (), onPause: @escaping () -> (), onStop: @escaping () -> ()) {
     m_manageAudioSession = manageAudioSession
@@ -60,6 +65,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     audioEngine.prepare()
     try audioEngine.start()
     m_shouldBeRunning = true
+    m_currentInputUID = AVAudioSession.sharedInstance().currentRoute.inputs.first?.uid
 
     // Observe AVAudioEngine configuration changes. Fires when the engine's
     // I/O format changes, e.g. after a route change that alters sample rate
@@ -129,9 +135,19 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
       return
     }
     switch reason {
-    case .newDeviceAvailable, .oldDeviceUnavailable, .routeConfigurationChange, .override:
+    case .newDeviceAvailable, .oldDeviceUnavailable, .routeConfigurationChange:
       print("[record_ios] Route change recovery triggered (reason=\(reason.rawValue))")
       scheduleRouteRecovery()
+    case .override:
+      // .override covers both input overrides (setPreferredInput) and output
+      // overrides (overrideOutputAudioPort). Only recover when the input
+      // route actually changed, otherwise output-only toggles cause needless
+      // audio glitches.
+      let newInputUID = AVAudioSession.sharedInstance().currentRoute.inputs.first?.uid
+      if newInputUID != m_currentInputUID {
+        print("[record_ios] Route change recovery triggered (reason=override, input \(m_currentInputUID ?? "nil") -> \(newInputUID ?? "nil"))")
+        scheduleRouteRecovery()
+      }
     default:
       break
     }
@@ -158,6 +174,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
       if !audioEngine.isRunning {
         try audioEngine.start()
       }
+      m_currentInputUID = AVAudioSession.sharedInstance().currentRoute.inputs.first?.uid
     } catch {
       print("[record_ios] Failed to recover from route change: \(error)")
     }
@@ -185,6 +202,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     m_audioEngine?.stop()
     m_audioEngine = nil
     m_recordEventHandler = nil
+    m_currentInputUID = nil
 
     if let encoder = m_audioEncoder {
       encoder.dispose()

--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -16,10 +16,13 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
   private var m_audioEncoder: AudioEnc?
   private var m_outputFormat: AVAudioFormat?
 
-  // Retained so that the tap can be reinstalled after an AVAudioEngine
-  // configuration change (route change from plug/unplug of an external mic).
+  // Retained so that the tap can be reinstalled after an audio route
+  // change (user plugs or unplugs an external mic mid-session).
   private var m_recordEventHandler: RecordStreamHandler?
   private var m_configurationChangeObserver: NSObjectProtocol?
+  private var m_routeChangeObserver: NSObjectProtocol?
+  private var m_shouldBeRunning: Bool = false
+  private let m_recoveryQueue = DispatchQueue(label: "com.llfbandit.record.recovery")
 
   init(manageAudioSession: Bool, onRecord: @escaping () -> (), onPause: @escaping () -> (), onStop: @escaping () -> ()) {
     m_manageAudioSession = manageAudioSession
@@ -56,16 +59,26 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
 
     audioEngine.prepare()
     try audioEngine.start()
+    m_shouldBeRunning = true
 
-    // Observe engine configuration changes (fired when the audio I/O route
-    // changes mid-session, e.g. user plugs in or unplugs a USB/Lightning mic).
-    // Without this, the engine gets stopped by the system and our tap goes
-    // silent until the recorder is fully restarted by the host app.
+    // Observe AVAudioEngine configuration changes. Fires when the engine's
+    // I/O format changes, e.g. after a route change that alters sample rate
+    // or channel count.
     m_configurationChangeObserver = NotificationCenter.default.addObserver(
       forName: .AVAudioEngineConfigurationChange,
       object: audioEngine,
       queue: nil) { [weak self] _ in
-        self?.handleConfigurationChange()
+        self?.scheduleRouteRecovery()
+      }
+
+    // Also observe AVAudioSession route changes. Covers plug/unplug events
+    // where the format happens to match and the engine configuration change
+    // notification does not fire.
+    m_routeChangeObserver = NotificationCenter.default.addObserver(
+      forName: AVAudioSession.routeChangeNotification,
+      object: nil,
+      queue: nil) { [weak self] notification in
+        self?.handleRouteChangeNotification(notification)
       }
 
     m_onRecord()
@@ -109,12 +122,33 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
       }
   }
 
-  private func handleConfigurationChange() {
-    // Per Apple: when the engine's I/O unit observes a change to the input or
-    // output hardware's channel count or sample rate, the engine stops itself
-    // and uninitializes. The tap installed against the old inputNode is gone.
-    // We must re-tap the (recreated) inputNode with its new input format and
-    // a fresh converter, then start the engine again.
+  private func handleRouteChangeNotification(_ notification: Notification) {
+    guard let userInfo = notification.userInfo,
+          let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+          let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else {
+      return
+    }
+    switch reason {
+    case .newDeviceAvailable, .oldDeviceUnavailable, .routeConfigurationChange:
+      scheduleRouteRecovery()
+    default:
+      break
+    }
+  }
+
+  private func scheduleRouteRecovery() {
+    // Notifications may arrive on arbitrary threads. Serialize recovery onto
+    // a dedicated queue so overlapping notifications coalesce naturally and
+    // we never mutate the engine from AVFoundation's posting thread.
+    m_recoveryQueue.async { [weak self] in
+      self?.performRouteRecovery()
+    }
+  }
+
+  private func performRouteRecovery() {
+    // Respect user intent: if the recorder has been paused or stopped, do
+    // not auto-resume just because a route changed.
+    guard m_shouldBeRunning else { return }
     guard let audioEngine = m_audioEngine, let config = config else { return }
 
     do {
@@ -124,14 +158,20 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
         try audioEngine.start()
       }
     } catch {
-      print("[record_ios] Failed to handle configuration change: \(error)")
+      print("[record_ios] Failed to recover from route change: \(error)")
     }
   }
 
   func stop(completionHandler: @escaping (String?) -> ()) {
+    m_shouldBeRunning = false
+
     if let observer = m_configurationChangeObserver {
       NotificationCenter.default.removeObserver(observer)
       m_configurationChangeObserver = nil
+    }
+    if let observer = m_routeChangeObserver {
+      NotificationCenter.default.removeObserver(observer)
+      m_routeChangeObserver = nil
     }
 
     if let audioEngine = m_audioEngine {
@@ -158,12 +198,14 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
   }
   
   func pause() {
+    m_shouldBeRunning = false
     m_audioEngine?.pause()
     m_onPause()
   }
 
   func resume() throws {
     try m_audioEngine?.start()
+    m_shouldBeRunning = true
     m_onRecord()
   }
   

--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -15,21 +15,24 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
 
   private var m_audioEncoder: AudioEnc?
   private var m_outputFormat: AVAudioFormat?
-  
+
+  // Retained so that the tap can be reinstalled after an AVAudioEngine
+  // configuration change (route change from plug/unplug of an external mic).
+  private var m_recordEventHandler: RecordStreamHandler?
+  private var m_configurationChangeObserver: NSObjectProtocol?
+
   init(manageAudioSession: Bool, onRecord: @escaping () -> (), onPause: @escaping () -> (), onStop: @escaping () -> ()) {
     m_manageAudioSession = manageAudioSession
     m_onRecord = onRecord
     m_onPause = onPause
     m_onStop = onStop
   }
-  
+
   func start(config: RecordConfig, recordEventHandler: RecordStreamHandler) throws {
     let audioEngine = AVAudioEngine()
 
     try initAVAudioSession(config: config, manageAudioSession: m_manageAudioSession)
     try setVoiceProcessing(echoCancel: config.echoCancel, autoGain: config.autoGain, audioEngine: audioEngine)
-
-    let srcFormat = audioEngine.inputNode.inputFormat(forBus: 0)
 
     m_outputFormat = AVAudioFormat(
       commonFormat: .pcmFormatInt16,
@@ -38,12 +41,49 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
       interleaved: true
     )
 
-    guard let dstFormat = m_outputFormat else {
+    guard m_outputFormat != nil else {
       throw RecorderError.error(
         message: "Failed to start recording",
         details: "Format is not supported: \(config.sampleRate)Hz - \(config.numChannels) channels."
       )
     }
+
+    self.m_audioEngine = audioEngine
+    self.config = config
+    self.m_recordEventHandler = recordEventHandler
+
+    try installInputTap(bufferSize: AVAudioFrameCount(config.streamBufferSize ?? 1024))
+
+    audioEngine.prepare()
+    try audioEngine.start()
+
+    // Observe engine configuration changes (fired when the audio I/O route
+    // changes mid-session, e.g. user plugs in or unplugs a USB/Lightning mic).
+    // Without this, the engine gets stopped by the system and our tap goes
+    // silent until the recorder is fully restarted by the host app.
+    m_configurationChangeObserver = NotificationCenter.default.addObserver(
+      forName: .AVAudioEngineConfigurationChange,
+      object: audioEngine,
+      queue: nil) { [weak self] _ in
+        self?.handleConfigurationChange()
+      }
+
+    m_onRecord()
+  }
+
+  // Reinstall the tap on the input node using the current input format and a
+  // fresh AVAudioConverter. Safe to call both on initial start and from the
+  // configuration change handler; the caller must ensure any existing tap has
+  // been removed first when appropriate.
+  private func installInputTap(bufferSize: AVAudioFrameCount) throws {
+    guard let audioEngine = m_audioEngine, let dstFormat = m_outputFormat else {
+      return
+    }
+
+    // Re-read the current input format. After a route change the inputNode
+    // is lazily recreated against the new hardware, so this reflects the
+    // connected device's native sample rate and channel count.
+    let srcFormat = audioEngine.inputNode.inputFormat(forBus: 0)
 
     guard let converter = AVAudioConverter(from: srcFormat, to: dstFormat) else {
       throw RecorderError.error(
@@ -53,30 +93,47 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     }
     converter.sampleRateConverterQuality = AVAudioQuality.high.rawValue
 
-
     audioEngine.inputNode.installTap(
       onBus: m_bus,
-      bufferSize: AVAudioFrameCount(config.streamBufferSize ?? 1024),
-      format: srcFormat) { (buffer, _) -> Void in
-
+      bufferSize: bufferSize,
+      format: srcFormat) { [weak self] (buffer, _) -> Void in
+        guard let self = self, let handler = self.m_recordEventHandler else {
+          return
+        }
         self.stream(
           buffer: buffer,
           dstFormat: dstFormat,
           converter: converter,
-          recordEventHandler: recordEventHandler
+          recordEventHandler: handler
         )
       }
-
-    audioEngine.prepare()
-    try audioEngine.start()
-
-    self.m_audioEngine = audioEngine
-    self.config = config
-
-    m_onRecord()
   }
-  
+
+  private func handleConfigurationChange() {
+    // Per Apple: when the engine's I/O unit observes a change to the input or
+    // output hardware's channel count or sample rate, the engine stops itself
+    // and uninitializes. The tap installed against the old inputNode is gone.
+    // We must re-tap the (recreated) inputNode with its new input format and
+    // a fresh converter, then start the engine again.
+    guard let audioEngine = m_audioEngine, let config = config else { return }
+
+    do {
+      audioEngine.inputNode.removeTap(onBus: m_bus)
+      try installInputTap(bufferSize: AVAudioFrameCount(config.streamBufferSize ?? 1024))
+      if !audioEngine.isRunning {
+        try audioEngine.start()
+      }
+    } catch {
+      print("[record_ios] Failed to handle configuration change: \(error)")
+    }
+  }
+
   func stop(completionHandler: @escaping (String?) -> ()) {
+    if let observer = m_configurationChangeObserver {
+      NotificationCenter.default.removeObserver(observer)
+      m_configurationChangeObserver = nil
+    }
+
     if let audioEngine = m_audioEngine {
       do {
         try setVoiceProcessing(echoCancel: false, autoGain: false, audioEngine: audioEngine)
@@ -86,6 +143,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     m_audioEngine?.inputNode.removeTap(onBus: m_bus)
     m_audioEngine?.stop()
     m_audioEngine = nil
+    m_recordEventHandler = nil
 
     if let encoder = m_audioEncoder {
       encoder.dispose()


### PR DESCRIPTION
## Summary

`RecorderStreamDelegate` on iOS does not react to `AVAudioEngineConfigurationChange` notifications. When the user plugs in or unplugs an external microphone (USB-C, Lightning, Bluetooth accessory) during an active streaming recording, the `AVAudioEngine` is stopped and uninitialized by the system (per Apple docs), the tap installed against the old `inputNode` is gone, and the PCM stream silently dies. The host app has no way to recover short of tearing down the entire `AudioRecorder` and creating a new one, which causes a 1-2 second audio gap and is easy to get wrong from the Dart side.

This change makes the streaming recorder resilient to route changes: on a configuration-change notification the stale tap is removed, the tap is reinstalled against the (recreated) `inputNode` using its current input format, a fresh `AVAudioConverter` is built, and the engine is restarted. Audio keeps flowing onto the new route with a minimal glitch.

## Reproduction

Tested on an iPhone 15 running the current public iOS with a USB-C external microphone. Before the fix:

1. Start a PCM stream session with the built-in mic.
2. Plug in the external mic mid-session.
3. Observable: all audio input stops. No pause/resume or config update recovers it. Must call `stop()` + `start()` to resume.
4. With the external mic plugged in first, start a session, then unplug mid-session: same symptom.

After the fix: in both scenarios, audio continues on the new route after a brief glitch.

## Changes

Only `record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift`:

- Extract tap installation into a private `installInputTap(bufferSize:)` method that re-reads `inputNode.inputFormat(forBus: 0)` and builds a fresh `AVAudioConverter`. Callable both on initial start and after a configuration change.
- Retain the `RecordStreamHandler` reference on the delegate (`m_recordEventHandler`) so the new tap closure can forward buffers to the same event sink after a re-tap.
- Observe `.AVAudioEngineConfigurationChange` on the engine in `start()` and store the observer token in `m_configurationChangeObserver`.
- In the handler `handleConfigurationChange()`, remove the stale tap, call `installInputTap`, and restart the engine if it is no longer running.
- Tear down the observer in `stop()` and null out the retained handler.

No public API changes.

## References

- [Apple: Responding to audio route changes](https://developer.apple.com/documentation/avfaudio/responding-to-audio-route-changes)
- [Apple: AVAudioEngineConfigurationChangeNotification](https://developer.apple.com/documentation/avfoundation/avaudioengine/configurationchangenotification)

## Test plan

- [x] Manual: plug/unplug USB-C mic during a PCM stream session on iPhone 15, verify audio continues on the new route.
- [x] Regression: normal start/stop of a PCM stream session still works.
- [ ] Manual: repeat with an AAC-streaming session once the AAC encoder path gets similar coverage (this PR only touches the stream delegate, AAC falls through the same path).
- [ ] Manual: repeat with a Bluetooth HFP headset connect/disconnect.

## Notes

Filing this because we hit it in production on iOS via the Flutter `record` package. Happy to iterate on the fix if the maintainers prefer a different shape (e.g. observing `AVAudioSession.routeChangeNotification` additionally, debouncing, or dispatching the handler onto a specific queue). No unit tests in this PR because the notification path requires a real device; open to adding XCTestCase-based smoke coverage if you would like.