### PR TITLE
fix(iOS/macOS): PCM/WAV slow playback caused by channel mismatch and unintended sample rate adjustment

### DIFF
--- a/record_ios/CHANGELOG.md
+++ b/record_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+* fix: Clamp PCM/WAV channel count to hardware input maximum to prevent slow playback when more channels are requested than the device supports.
+* fix: Preserve user-specified sample rate for PCM/WAV encoders regardless of converter availability.
+
 ## 2.0.1
 fix: Wrong error code.
 fix: Don't override AVAudioSession.Category if there's no need for listing devices.

--- a/record_ios/ios/record_ios/Sources/record_ios/extension/RecorderFormatExtension.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/extension/RecorderFormatExtension.swift
@@ -18,7 +18,7 @@ extension AudioRecordingDelegate {
     let format = AVAudioFormat(
       commonFormat: AVAudioCommonFormat.pcmFormatInt16,
       sampleRate: (config.sampleRate < 48000) ? Double(config.sampleRate) : 48000.0,
-      channels: UInt32((config.numChannels > 2) ? 2 : config.numChannels),
+      channels: UInt32(effectiveNumChannels(config.numChannels)),
       interleaved: false
     )
 
@@ -100,7 +100,7 @@ extension AudioRecordingDelegate {
         AVLinearPCMIsBigEndianKey: false,
         AVLinearPCMIsNonInterleaved: false,
         AVSampleRateKey: config.sampleRate,
-        AVNumberOfChannelsKey: config.numChannels,
+        AVNumberOfChannelsKey: effectiveNumChannels(config.numChannels),
         AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
       ]
       keepSampleRate = true
@@ -112,7 +112,7 @@ extension AudioRecordingDelegate {
         AVLinearPCMIsBigEndianKey: false,
         AVLinearPCMIsNonInterleaved: false,
         AVSampleRateKey: config.sampleRate,
-        AVNumberOfChannelsKey: config.numChannels,
+        AVNumberOfChannelsKey: effectiveNumChannels(config.numChannels),
         AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
       ]
       keepSampleRate = true
@@ -137,7 +137,8 @@ extension AudioRecordingDelegate {
       throw RecorderError.error(message: "Failed to start recording", details: "Format conversion isn’t possible. Format or configuration is not supported.")
     }
 
-    if let sampleRate = settings[AVSampleRateKey] as? NSNumber,
+    if !keepSampleRate,
+       let sampleRate = settings[AVSampleRateKey] as? NSNumber,
        let sampleRates = converter.availableEncodeSampleRates {
       settings[AVSampleRateKey] = nearestValue(values: sampleRates, value: sampleRate, key: "sample rates").floatValue
     } else if !keepSampleRate {
@@ -154,6 +155,12 @@ extension AudioRecordingDelegate {
     return settings
   }
   
+  private func effectiveNumChannels(_ numChannels: Int) -> Int {
+    let maxChannels = AVAudioSession.sharedInstance().maximumInputNumberOfChannels
+    guard maxChannels > 0 else { return min(numChannels, 2) }
+    return min(numChannels, maxChannels)
+  }
+
   private func nearestValue(values: [NSNumber], value: NSNumber, key: String) -> NSNumber {
     // Sometimes converter does not give any good listing
     if values.count == 0 || (values.count == 1 && values[0] == 0) {

--- a/record_macos/CHANGELOG.md
+++ b/record_macos/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* fix: Preserve user-specified sample rate for PCM/WAV encoders regardless of converter availability.
+
 ## 2.0.0
 * chore: Completes Swift Package Manager integration.
 * chore: Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.

--- a/record_macos/macos/record_macos/Sources/record_macos/extension/RecorderFormatExtension.swift
+++ b/record_macos/macos/record_macos/Sources/record_macos/extension/RecorderFormatExtension.swift
@@ -134,7 +134,8 @@ extension AudioRecordingDelegate {
       throw RecorderError.error(message: "Failed to start recording", details: "Format conversion isn’t possible. Format or configuration is not supported.")
     }
 
-    if let sampleRate = settings[AVSampleRateKey] as? NSNumber,
+    if !keepSampleRate,
+       let sampleRate = settings[AVSampleRateKey] as? NSNumber,
        let sampleRates = converter.availableEncodeSampleRates {
       settings[AVSampleRateKey] = nearestValue(values: sampleRates, value: sampleRate, key: "sample rates").floatValue
     } else if !keepSampleRate {


### PR DESCRIPTION
## Problem

Fixes #587

When recording PCM/WAV on iOS with the default config (`numChannels: 2`),
playback of the resulting file is often at half speed or slower on devices
where the hardware microphone only supports 1 input channel (most iPhones
and some iPads).

Two bugs combine to cause this:

**1. Channel count mismatch**
`initAVAudioSession` correctly clamps the audio session's preferred input
channels to `AVAudioSession.maximumInputNumberOfChannels` (e.g. 1 on a
typical iPhone), but `getOutputSettings` still wrote the raw
`config.numChannels` (e.g. 2) into `AVNumberOfChannelsKey`. The
`AVAudioRecorder` then records at the session's actual rate (1 channel)
but declares 2 channels in the WAV/PCM header, so every player reads
twice as much data per frame as actually exists → half-speed playback.

**2. Sample rate silently adjusted for PCM/WAV**
The `keepSampleRate` flag was intended to preserve the user's exact sample
rate for raw formats, but it only guarded the `else` (remove-key) branch.
When `converter.availableEncodeSampleRates` was non-nil, `nearestValue`
could still adjust the rate even for PCM/WAV — ignoring the user's intent
and potentially mismatching the actual recorded data rate with the header.

## Changes

**iOS `RecorderFormatExtension.swift`**
- Add `effectiveNumChannels(_:)` — clamps the requested channel count to
  `AVAudioSession.sharedInstance().maximumInputNumberOfChannels`. Falls
  back to `min(numChannels, 2)` when the session reports 0 (inactive).
- Use `effectiveNumChannels` for `AVNumberOfChannelsKey` in both PCM16
  and WAV output settings, and for the input format used in converter
  validation.
- Guard the `availableEncodeSampleRates` branch with `!keepSampleRate`
  so PCM/WAV always honour the user's requested sample rate.

**macOS `RecorderFormatExtension.swift`**
- Same `keepSampleRate` guard applied (macOS uses `AVCaptureSession` so
  the channel-clamping helper is iOS-only).

## Testing

Verified against the scenario from #587:
```dart
RecordConfig(
  encoder: AudioEncoder.pcm16bits,
  echoCancel: true,
  noiseSuppress: true,
  sampleRate: 24000,
  // numChannels defaults to 2
)
