### PR TITLE
feat(Android): expose per-device supported sample rates via InputDevice.sampleRates

### DIFF
--- a/record_android/CHANGELOG.md
+++ b/record_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+* feat: Expose device sample rates via `InputDevice.sampleRates` using `AudioDeviceInfo.getSampleRates()`.
+
 ## 2.0.2
 * fix: Bluetooth SCO connection before audio recording.
 * fix: Prevents potential double pause event.

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/device/DeviceUtils.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/device/DeviceUtils.kt
@@ -7,7 +7,7 @@ import android.os.Build
 
 class DeviceUtils {
   companion object {
-    fun listInputDevicesAsMap(context: Context): List<Map<String, String>> {
+    fun listInputDevicesAsMap(context: Context): List<Map<String, Any>> {
       val devices = listInputDevices(context).map {
         val label = StringBuilder()
         label.apply {
@@ -18,10 +18,17 @@ class DeviceUtils {
           append(")")
         }
 
-        mapOf(
+        val map = mutableMapOf<String, Any>(
           "id" to "${it.id}",
           "label" to label.toString(),
         )
+
+        val rates = it.sampleRates
+        if (rates.isNotEmpty()) {
+          map["sampleRates"] = rates.toList()
+        }
+
+        map
       }
 
       return devices

--- a/record_platform_interface/CHANGELOG.md
+++ b/record_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+* feat: Add `sampleRates` field to `InputDevice` — populated on Android; `null` on other platforms.
+
 ## 2.0.0
 * chore: Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 

--- a/record_platform_interface/lib/src/types/input_device.dart
+++ b/record_platform_interface/lib/src/types/input_device.dart
@@ -5,19 +5,31 @@ class InputDevice {
   /// The label text representation.
   final String label;
 
+  /// The sample rates supported by this device.
+  ///
+  /// `null` means the device did not report specific rates (all standard
+  /// rates are assumed to be supported).
+  ///
+  /// Currently populated on Android only. iOS and macOS do not expose
+  /// per-device sample rate capabilities through a public API.
+  final List<int>? sampleRates;
+
   const InputDevice({
     required this.id,
     required this.label,
+    this.sampleRates,
   });
 
   factory InputDevice.fromMap(Map map) => InputDevice(
         id: map['id'],
         label: map['label'],
+        sampleRates: (map['sampleRates'] as List?)?.cast<int>(),
       );
 
   Map<String, dynamic> toMap() => {
         'id': id,
         'label': label,
+        if (sampleRates != null) 'sampleRates': sampleRates,
       };
 
   @override
@@ -25,6 +37,7 @@ class InputDevice {
     return '''
       id: $id
       label: $label
+      sampleRates: $sampleRates
       ''';
   }
 


### PR DESCRIPTION
## Summary

Closes #216

`AudioDeviceInfo.getSampleRates()` has always been available on Android,
but the data was never surfaced to Dart. This PR wires it up with a
minimal, backwards-compatible change.

## Problem

When a Bluetooth SCO device is active, it is typically limited to 8 kHz
or 16 kHz. There was no way for callers to know this before starting a
recording, so they would either hard-code a low rate for everyone or
silently produce a degraded/incorrect recording for BT users.

## Changes

**`record_platform_interface`**
- Add `sampleRates: List<int>?` to `InputDevice`.
  - `null` → the OS reported no specific caps (all standard rates are
    assumed to work, e.g. built-in microphone).
  - Non-null → the exact list returned by `AudioDeviceInfo.getSampleRates()`.

**`record_android`**
- `DeviceUtils.listInputDevicesAsMap` return type widened from
  `List<Map<String, String>>` to `List<Map<String, Any>>` to accommodate
  the rates list.
- `sampleRates` is only included in the map when the device reports a
  non-empty array; otherwise the key is absent (Dart reads `null`).

iOS and macOS have no public API for per-device sample rate capabilities
and are unaffected — `InputDevice.sampleRates` will be `null` there.

## Usage

```dart
final devices = await recorder.listInputDevices();

for (final device in devices) {
  if (device.sampleRates != null) {
    print('${device.label} supports: ${device.sampleRates} Hz');
  } else {
    print('${device.label}: no rate restrictions reported');
  }
}

// Pick a safe rate before starting
final rates = selectedDevice.sampleRates;
final sampleRate = (rates != null && !rates.contains(44100))
    ? rates.reduce((a, b) => (a - 44100).abs() < (b - 44100).abs() ? a : b)
    : 44100;

await recorder.start(
  RecordConfig(sampleRate: sampleRate, device: selectedDevice),
  path: path,
);
