### PR TITLE
fix(Android): update WaveFormat frameSize when numChannels is adjusted

### DIFF
--- a/record_android/android/src/main/kotlin/com/llfbandit/record/record/format/WaveFormat.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/record/format/WaveFormat.kt
@@ -10,6 +10,12 @@ class WaveFormat : Format() {
 
   private var frameSize: Int = 0
 
+  override fun adjustNumChannels(format: MediaFormat, numChannels: Int) {
+    super.adjustNumChannels(format, numChannels)
+    frameSize = numChannels * 16 / 8
+    format.setInteger(KEY_X_FRAME_SIZE_IN_BYTES, frameSize)
+  }
+
   override fun getMediaFormat(config: RecordConfig): MediaFormat {
     val bitsPerSample = 16
     frameSize = config.numChannels * bitsPerSample / 8


### PR DESCRIPTION
## Description

When `FormatCodecSelector.adjustToDeviceCapabilities()` changes `numChannels` for a device (e.g. Bluetooth headset reporting `channelCounts = [2]`), `WaveFormat.frameSize` is not updated because `WaveFormat` does not override `adjustNumChannels()`.

This causes `WaveContainer` to build incorrect WAV headers:
- `blockAlign` stays at the old value (e.g. 2 instead of 4)
- `bitsPerSample` is calculated as `(frameSize / channelCount) * 8` → 8 instead of 16
- `byteRate` is half of the correct value

The result is garbled/distorted audio playback from the recorded WAV file.

### The Fix

Override `adjustNumChannels()` in `WaveFormat` to recalculate `frameSize` and update `KEY_X_FRAME_SIZE_IN_BYTES` in the `MediaFormat`, following the same pattern already used by `AacFormat`.

### Impact

- Fixes corrupted WAV recordings when device capabilities force a channel count change
- Affects Bluetooth headsets and USB microphones that only support stereo
- No impact on devices where `numChannels` is not adjusted

### To Reproduce

```dart
RecordConfig(
  encoder: AudioEncoder.wav,
  sampleRate: 48000,
  numChannels: 1,
  device: <bluetooth or USB device that reports channelCounts=[2]>,
)
```

Logcat output showing the issue:
```
D/nearestValue: Available values: [2]
D/nearestValue: Adjusted to: 2
```

After recording, the WAV header shows `bitsPerSample: 8` instead of the expected `16`.

---

We use this package in [LISTEN](https://listen.style), a podcast platform ([App Store](https://apps.apple.com/us/app/listen-style-podcast-platform/id6743028071) / [Google Play](https://play.google.com/store/apps/details?id=style.listen)). It's a core part of our recording feature and we're very grateful for this great package. Thank you for maintaining it! 🙏