### PR TITLE
Fix ~230 ms Flutter UI freeze when Android recording starts

### DIFF
--- a/record_android/android/build.gradle.kts
+++ b/record_android/android/build.gradle.kts
@@ -45,3 +45,7 @@ kotlin {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
+
+dependencies {
+    testImplementation("junit:junit:4.13.2")
+}

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/MethodCallHandlerImpl.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/MethodCallHandlerImpl.kt
@@ -1,6 +1,9 @@
 package com.llfbandit.record
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import com.llfbandit.record.permission.PermissionManager
 import com.llfbandit.record.record.format.AudioFormats
 import com.llfbandit.record.record.model.RecordConfig
@@ -9,13 +12,22 @@ import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
 
 class MethodCallHandlerImpl(
   private val permissionManager: PermissionManager,
   private val messenger: BinaryMessenger,
   private val appContext: Context
 ) : MethodChannel.MethodCallHandler {
-  private val recorders = ConcurrentHashMap<String, RecorderWrapper>()
+  private data class RecorderEntry(
+    val recorder: RecorderWrapper,
+    val calls: RecorderCallQueue
+  )
+
+  private val recorders = ConcurrentHashMap<String, RecorderEntry>()
+  private val disposingRecorders = ConcurrentHashMap<String, RecorderEntry>()
+  private val uiThreadHandler = Handler(Looper.getMainLooper())
+  private var disposed = false
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
     val recorderId = call.argument<String>("recorderId")
@@ -30,8 +42,8 @@ class MethodCallHandlerImpl(
       return
     }
 
-    val recorder = recorders[recorderId]
-    if (recorder == null) {
+    val entry = recorders[recorderId]
+    if (entry == null) {
       result.error(
         "record",
         "Recorder has not yet been created or has already been disposed.", null
@@ -40,45 +52,127 @@ class MethodCallHandlerImpl(
     }
 
     when (call.method) {
-      "start" -> recorder.startRecordingToFile(RecordConfig.fromMap(call, appContext), result)
-      "startStream" -> recorder.startRecordingToStream(RecordConfig.fromMap(call, appContext), result)
-      "stop" -> recorder.stop(result)
-      "pause" -> recorder.pause(result)
-      "resume" -> recorder.resume(result)
-      "isPaused" -> recorder.isPaused(result)
-      "isRecording" -> recorder.isRecording(result)
-      "cancel" -> recorder.cancel(result)
+      "start" -> dispatch(entry, result) {
+        entry.recorder.startRecordingToFile(RecordConfig.fromMap(call, appContext), result)
+      }
+      "startStream" -> dispatch(entry, result) {
+        entry.recorder.startRecordingToStream(RecordConfig.fromMap(call, appContext), result)
+      }
+      "stop" -> dispatch(entry, result) { entry.recorder.stop(result) }
+      "pause" -> dispatch(entry, result) { entry.recorder.pause(result) }
+      "resume" -> dispatch(entry, result) { entry.recorder.resume(result) }
+      "isPaused" -> dispatch(entry, result) { entry.recorder.isPaused(result) }
+      "isRecording" -> dispatch(entry, result) { entry.recorder.isRecording(result) }
+      "cancel" -> dispatch(entry, result) { entry.recorder.cancel(result) }
       "hasPermission" -> hasPermission(call, result)
-      "getAmplitude" -> recorder.getAmplitude(result)
-      "listInputDevices" -> result.success(DeviceUtils.listInputDevicesAsMap(appContext))
-      "dispose" -> disposeRecorder(recorder, recorderId, result)
-      "isEncoderSupported" -> isEncoderSupported(call, result)
+      "getAmplitude" -> dispatch(entry, result) { entry.recorder.getAmplitude(result) }
+      "listInputDevices" -> dispatch(entry, result) {
+        result.success(DeviceUtils.listInputDevicesAsMap(appContext))
+      }
+      "dispose" -> disposeRecorder(entry, recorderId, result)
+      "isEncoderSupported" -> dispatch(entry, result) { isEncoderSupported(call, result) }
       else -> result.notImplemented()
     }
   }
 
   fun dispose() {
-    for (entry in recorders.entries) {
-      disposeRecorder(entry.value, entry.key, null)
+    disposed = true
+    val entries = (recorders.values + disposingRecorders.values).distinct()
+    recorders.clear()
+    disposingRecorders.clear()
+
+    val cleanupFutures = entries.map { entry ->
+      entry.calls.close { entry.recorder.disposeRecorder() }
     }
 
-    recorders.clear()
+    var interrupted = false
+    for (future in cleanupFutures) {
+      while (true) {
+        try {
+          future.get()
+          break
+        } catch (e: InterruptedException) {
+          interrupted = true
+          Log.w(TAG, "Interrupted while disposing recorder", e)
+        } catch (e: ExecutionException) {
+          Log.w(TAG, "Failed to dispose recorder", e.cause)
+          break
+        }
+      }
+    }
+
+    entries.forEach { it.recorder.detachChannels() }
+    if (interrupted) Thread.currentThread().interrupt()
   }
 
   private fun createRecorder(recorderId: String, result: MethodChannel.Result) {
+    if (recorders.containsKey(recorderId) || disposingRecorders.containsKey(recorderId)) {
+      result.error("record", "Recorder has already been created or is being disposed.", null)
+      return
+    }
+
     try {
-      val recorder = RecorderWrapper(appContext, recorderId, messenger)
-      recorders[recorderId] = recorder
+      val calls = RecorderCallQueue("RecordMethodCall-$recorderId")
+      val recorder = RecorderWrapper(appContext, recorderId, messenger, calls::executeOrRun)
+      recorders[recorderId] = RecorderEntry(recorder, calls)
       result.success(null)
     } catch (e: Exception) {
       result.error("record", "Cannot create recorder.", e.message)
     }
   }
 
-  private fun disposeRecorder(recorder: RecorderWrapper, recorderId: String, result: MethodChannel.Result?) {
-    recorder.dispose()
-    recorders.remove(recorderId)
-    result?.success(null)
+  private fun dispatch(
+    entry: RecorderEntry,
+    result: MethodChannel.Result,
+    call: () -> Unit
+  ) {
+    val accepted = entry.calls.execute {
+      try {
+        call()
+      } catch (e: Exception) {
+        result.error("record", e.message, e.cause)
+      }
+    }
+
+    if (!accepted) {
+      result.error(
+        "record",
+        "Recorder has not yet been created or has already been disposed.",
+        null
+      )
+    }
+  }
+
+  private fun disposeRecorder(
+    entry: RecorderEntry,
+    recorderId: String,
+    result: MethodChannel.Result?
+  ) {
+    if (!recorders.remove(recorderId, entry)) {
+      result?.error(
+        "record",
+        "Recorder has not yet been created or has already been disposed.",
+        null
+      )
+      return
+    }
+
+    disposingRecorders[recorderId] = entry
+    entry.calls.close {
+      try {
+        entry.recorder.disposeRecorder()
+      } finally {
+        uiThreadHandler.post {
+          if (!disposed) {
+            entry.recorder.detachChannels()
+            disposingRecorders.remove(recorderId, entry)
+            result?.success(null)
+          } else {
+            disposingRecorders.remove(recorderId, entry)
+          }
+        }
+      }
+    }
   }
 
   private fun hasPermission(call: MethodCall, result: MethodChannel.Result) {
@@ -94,5 +188,9 @@ class MethodCallHandlerImpl(
     )
 
     result.success(isSupported)
+  }
+
+  companion object {
+    private const val TAG = "RecordPlugin"
   }
 }

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/RecorderCallQueue.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/RecorderCallQueue.kt
@@ -1,0 +1,58 @@
+package com.llfbandit.record
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.RejectedExecutionException
+
+internal class RecorderCallQueue(
+  threadName: String,
+  private val executor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+    Thread(runnable, threadName).apply { isDaemon = true }
+  }
+) {
+  private val executing = ThreadLocal<Boolean>()
+  private var closed = false
+  private var closeFuture: Future<*>? = null
+
+  @Synchronized
+  fun execute(call: () -> Unit): Boolean {
+    if (closed) return false
+
+    return try {
+      executor.execute(wrap(call))
+      true
+    } catch (_: RejectedExecutionException) {
+      false
+    }
+  }
+
+  fun executeOrRun(call: () -> Unit): Boolean {
+    if (executing.get() == true) {
+      call()
+      return true
+    }
+
+    return execute(call)
+  }
+
+  @Synchronized
+  fun close(cleanup: () -> Unit): Future<*> {
+    closeFuture?.let { return it }
+    closed = true
+
+    val cleanupFuture = executor.submit(wrap(cleanup))
+    closeFuture = cleanupFuture
+    executor.shutdown()
+    return cleanupFuture
+  }
+
+  private fun wrap(call: () -> Unit) = Runnable {
+    executing.set(true)
+    try {
+      call()
+    } finally {
+      executing.remove()
+    }
+  }
+}

--- a/record_android/android/src/main/kotlin/com/llfbandit/record/RecorderWrapper.kt
+++ b/record_android/android/src/main/kotlin/com/llfbandit/record/RecorderWrapper.kt
@@ -1,6 +1,8 @@
 package com.llfbandit.record
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.llfbandit.record.record.bluetooth.BluetoothManager
 import com.llfbandit.record.record.model.RecordConfig
 import com.llfbandit.record.record.recorder.AudioRecorder
@@ -16,6 +18,7 @@ class RecorderWrapper(
   private val context: Context,
   recorderId: String,
   messenger: BinaryMessenger,
+  private val dispatch: (() -> Unit) -> Boolean,
 ) {
   companion object {
     const val EVENTS_STATE_CHANNEL = "com.llfbandit.record/events/"
@@ -30,6 +33,8 @@ class RecorderWrapper(
   private val configChangedChannel: MethodChannel
   private var recorder: IRecorder? = null
   private val bluetoothManager = BluetoothManager(context)
+  private val uiThreadHandler = Handler(Looper.getMainLooper())
+  private var channelsAttached = true
 
   init {
     eventChannel = EventChannel(messenger, EVENTS_STATE_CHANNEL + recorderId)
@@ -50,7 +55,7 @@ class RecorderWrapper(
     startRecording(config, result)
   }
 
-  fun dispose() {
+  fun disposeRecorder() {
     try {
       recorder?.dispose()
     } catch (_: Exception) {
@@ -58,7 +63,10 @@ class RecorderWrapper(
       bluetoothManager.stop()
       recorder = null
     }
+  }
 
+  fun detachChannels() {
+    channelsAttached = false
     eventChannel?.setStreamHandler(null)
     eventChannel = null
 
@@ -130,21 +138,41 @@ class RecorderWrapper(
   private fun startRecording(config: RecordConfig, result: MethodChannel.Result) {
     try {
       if (recorder == null) {
-        bluetoothManager.maybeStart(config) {
+        startAfterBluetooth(config, result) {
           recorder = createRecorder(config)
           start(config, result)
         }
       } else if (recorder!!.isRecording) {
-        recorder!!.stop(fun(_) = bluetoothManager.maybeStart(config) {
-          start(config, result)
-        })
+        recorder!!.stop(fun(_) = startAfterBluetooth(config, result) { start(config, result) })
       } else {
-        bluetoothManager.maybeStart(config) {
-          start(config, result)
-        }
+        startAfterBluetooth(config, result) { start(config, result) }
       }
     } catch (e: Exception) {
       result.error("record", e.message, e.cause)
+    }
+  }
+
+  private fun startAfterBluetooth(
+    config: RecordConfig,
+    result: MethodChannel.Result,
+    start: () -> Unit
+  ) {
+    bluetoothManager.maybeStart(config) {
+      val accepted = dispatch {
+        try {
+          start()
+        } catch (e: Exception) {
+          result.error("record", e.message, e.cause)
+        }
+      }
+
+      if (!accepted) {
+        result.error(
+          "record",
+          "Recorder has not yet been created or has already been disposed.",
+          null
+        )
+      }
     }
   }
 
@@ -172,6 +200,11 @@ class RecorderWrapper(
   }
 
   private fun notifyConfigChanged(config: RecordConfig) {
-    configChangedChannel.invokeMethod("onConfigChanged", config.toMap())
+    val configMap = config.toMap()
+    uiThreadHandler.post {
+      if (channelsAttached) {
+        configChangedChannel.invokeMethod("onConfigChanged", configMap)
+      }
+    }
   }
 }

--- a/record_android/android/src/test/kotlin/com/llfbandit/record/RecorderCallQueueTest.kt
+++ b/record_android/android/src/test/kotlin/com/llfbandit/record/RecorderCallQueueTest.kt
@@ -1,0 +1,96 @@
+package com.llfbandit.record
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecorderCallQueueTest {
+  @Test
+  fun executeReturnsWhileBlockedCallRuns() {
+    val executor = newExecutor()
+    val queue = RecorderCallQueue("unused", executor)
+    val firstStarted = CountDownLatch(1)
+    val releaseFirst = CountDownLatch(1)
+    val secondRan = CountDownLatch(1)
+
+    try {
+      assertTrue(queue.execute {
+        firstStarted.countDown()
+        releaseFirst.await()
+      })
+      assertTrue(firstStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+      assertTrue(queue.execute { secondRan.countDown() })
+      assertEquals(1L, secondRan.count)
+    } finally {
+      releaseFirst.countDown()
+      queue.close {}.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    }
+
+    assertTrue(secondRan.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+  }
+
+  @Test
+  fun callsAndCleanupRunInOrder() {
+    val executor = newExecutor()
+    val queue = RecorderCallQueue("unused", executor)
+    val calls = CopyOnWriteArrayList<Int>()
+
+    assertTrue(queue.execute { calls.add(1) })
+    assertTrue(queue.execute { calls.add(2) })
+    assertTrue(queue.execute { calls.add(3) })
+
+    queue.close { calls.add(4) }.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+    assertEquals(listOf(1, 2, 3, 4), calls)
+    assertTrue(executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+  }
+
+  @Test
+  fun closeIsIdempotentAndRejectsLaterCalls() {
+    val executor = newExecutor()
+    val queue = RecorderCallQueue("unused", executor)
+    val cleanupCalls = AtomicInteger()
+
+    val firstClose = queue.close { cleanupCalls.incrementAndGet() }
+    val secondClose = queue.close { cleanupCalls.incrementAndGet() }
+
+    assertSame(firstClose, secondClose)
+    firstClose.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    assertEquals(1, cleanupCalls.get())
+    assertFalse(queue.execute {})
+    assertFalse(queue.executeOrRun {})
+    assertTrue(executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+  }
+
+  @Test
+  fun executeOrRunKeepsNestedContinuationInPlace() {
+    val executor = newExecutor()
+    val queue = RecorderCallQueue("unused", executor)
+    val calls = CopyOnWriteArrayList<Int>()
+
+    assertTrue(queue.execute {
+      calls.add(1)
+      assertTrue(queue.executeOrRun { calls.add(2) })
+      calls.add(3)
+    })
+    queue.close { calls.add(4) }.get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+    assertEquals(listOf(1, 2, 3, 4), calls)
+  }
+
+  private fun newExecutor() = Executors.newSingleThreadExecutor { runnable ->
+    Thread(runnable, "RecorderCallQueueTest").apply { isDaemon = true }
+  }
+
+  companion object {
+    private const val TIMEOUT_SECONDS = 5L
+  }
+}


### PR DESCRIPTION
## Why

On Android, `AudioRecorder.start()` ultimately waits for `RecordThread` initialization through a `CountDownLatch`. `MethodCallHandlerImpl` currently invokes that work synchronously, so **starting a recording blocks Flutter's Android platform/UI thread while `AudioRecord` initializes**.

**This freezes visible Flutter UI feedback for the duration of recorder startup.** In an interface that animates immediately when the user presses a record control, the animation does not merely start late: its frames stop rendering until native initialization returns.

Repeated measurements on a Pixel 10 Pro running Android 17 showed:

- Recorder initialization taking roughly **224-311 ms**.
- The first press-feedback frame delayed to a **321.9 ms median** with the current synchronous implementation.
- The first feedback frame arriving in **13.7 ms median** after moving recorder startup off the platform thread, while initialization continued in the background.

The impact is not specific to one animation or application. Any Flutter UI expected to remain responsive while Android recording starts can visibly freeze because the plugin performs blocking native work on Flutter's platform thread.

## What

- Run each Android recorder's stateful method calls through its own serial worker queue.
- Route Bluetooth-SCO start continuations back through that same queue so asynchronous device setup cannot return blocking recorder work to the UI thread.
- Keep Flutter channel registration, notifications, and teardown on the UI thread.
- Preserve per-recorder call ordering and allow separate recorder instances to operate independently.
- Reject calls after disposal starts, reserve recorder IDs through teardown, and drain active or disposing queues during engine detach.
- Add JVM regression tests for nonblocking submission, FIFO ordering, nested continuations, closing, and executor termination.

## Complexity

Moderate. Moving the blocking call is small, but preserving recorder ordering, Bluetooth continuations, Flutter channel thread affinity, and engine-detach cleanup crosses several Android lifecycle boundaries.

## Risk and test focus

The main risks are call reordering, callbacks escaping back onto the UI thread, duplicate recorder IDs, and disposal racing startup. The implementation uses one serial queue per recorder, rejects calls once disposal starts, keeps recorder IDs reserved through channel teardown, and waits for queued cleanup during engine detach.

There is no Dart API, wire-contract, persisted-data, permission, or database impact.

## Expected result

Starting an Android recording no longer freezes Flutter UI feedback while native recorder initialization completes. Recorder method ordering and existing results remain intact, including with multiple recorder instances and lifecycle teardown.

## Verification

- `flutter analyze record_android`
- `flutter build apk --debug` from `record/example`
- `./gradlew :record_android:testDebugUnitTest` from `record/example/android`
