### PR TITLE
fix(ios): recover a silently stopped AVAudioEngine after a configuration change

### DIFF
--- a/record_ios/ios/record_ios/Sources/record_ios/RecordConfig.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/RecordConfig.swift
@@ -90,6 +90,7 @@ public class Device {
 struct IosConfig {
   let categoryOptions: [AVAudioSession.CategoryOptions]
   let allowHapticsAndSystemSoundsDuringRecording: Bool
+  let restartOnEngineConfigurationChange: Bool
 
   init(map: [String: Any]) {
     let comps = map["categoryOptions"] as? String
@@ -98,6 +99,7 @@ struct IosConfig {
     }
     self.categoryOptions = options ?? []
     self.allowHapticsAndSystemSoundsDuringRecording = map["allowHapticsAndSystemSoundsDuringRecording"] as? Bool ?? false
+    self.restartOnEngineConfigurationChange = map["restartOnEngineConfigurationChange"] as? Bool ?? false
   }
 
   static func avCategory(from string: String) -> AVAudioSession.Category {

--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -162,6 +162,15 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
           let recordEventHandler = m_recordEventHandler else { return }
 
     engine.inputNode.removeTap(onBus: m_bus)
+
+    // Before the new format is read, not after: the tap has to be installed
+    // against the input this session actually ends up on. If the route is still
+    // settling and the format read below is the outgoing device's, the move
+    // posts a further configuration change and this runs again — that second
+    // pass finds the wanted input already current, skips the re-pin, and
+    // installs the tap against the settled format.
+    reapplyPreferredInputDevice(config.device)
+
     let format = engine.inputNode.inputFormat(forBus: 0)
 
     do {

--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -8,6 +8,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
   private var m_audioEngine: AVAudioEngine?
   private var m_processor: AudioStreamProcessor?
   private var m_isPaused = false
+  private var m_recordEventHandler: RecordStreamHandler?
   private let m_lock = NSLock()
   private let m_bus = 0
   private let m_queue: DispatchQueue
@@ -16,6 +17,7 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
   private var m_onPause:  () -> ()
   private var m_onStop:   () -> ()
   private var m_interruptionObserver: NSObjectProtocol?
+  private var m_configChangeObserver: NSObjectProtocol?
 
   init(
     queue: DispatchQueue,
@@ -58,6 +60,18 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     m_audioEngine = engine
     m_lock.withLock { m_processor = processor }
     self.config = config
+    m_recordEventHandler = recordEventHandler
+
+    if config.iosConfig.restartOnEngineConfigurationChange {
+      m_configChangeObserver = NotificationCenter.default.addObserver(
+        forName: .AVAudioEngineConfigurationChange,
+        object: engine,
+        queue: nil
+      ) { [weak self] _ in
+        self?.m_queue.async { self?.restartAfterConfigurationChange() }
+      }
+    }
+
     m_onRecord()
   }
 
@@ -67,6 +81,11 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
       NotificationCenter.default.removeObserver(observer)
       m_interruptionObserver = nil
     }
+    if let observer = m_configChangeObserver {
+      NotificationCenter.default.removeObserver(observer)
+      m_configChangeObserver = nil
+    }
+    m_recordEventHandler = nil
 
     if let engine = m_audioEngine {
       do { try setVoiceProcessing(echoCancel: false, autoGain: false, audioEngine: engine) } catch {}
@@ -130,6 +149,36 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     guard let sink = recordEventHandler.eventSink else { return }
     for data in dataList {
       DispatchQueue.main.async { sink(FlutterStandardTypedData(bytes: data)) }
+    }
+  }
+
+  // The engine does not restart itself after a configuration change (route
+  // change, another app reconfiguring the shared session) — the tap must be
+  // reinstalled against the new format and the engine started again.
+  private func restartAfterConfigurationChange() {
+    guard !m_lock.withLock({ m_isPaused }),
+          let engine = m_audioEngine,
+          let config,
+          let recordEventHandler = m_recordEventHandler else { return }
+
+    engine.inputNode.removeTap(onBus: m_bus)
+    let format = engine.inputNode.inputFormat(forBus: 0)
+
+    do {
+      let processor = try AudioStreamProcessor(config: config, srcFormat: format)
+      engine.inputNode.installTap(
+        onBus: m_bus,
+        bufferSize: AVAudioFrameCount(config.streamBufferSize ?? 1024),
+        format: format
+      ) { [weak self] buffer, _ in
+        self?.handleTap(buffer: buffer, recordEventHandler: recordEventHandler)
+      }
+      m_lock.withLock { m_processor = processor }
+      engine.prepare()
+      try engine.start()
+      m_onRecord()
+    } catch {
+      _ = stop()
     }
   }
 

--- a/record_ios/ios/record_ios/Sources/record_ios/extension/RecorderSessionExtension.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/extension/RecorderSessionExtension.swift
@@ -19,6 +19,34 @@ extension AudioRecordingDelegate {
 
     return registerInterruptionObserver(queue: queue)
   }
+
+  /// Re-asserts `config.device` after the route has moved underneath a live
+  /// session.
+  ///
+  /// `setPreferredInput` is applied once, from `initAVAudioSession`, and iOS
+  /// drops that preference when it re-routes — so a Bluetooth headset or
+  /// CarPlay unit connecting mid-session captures the microphone for the rest
+  /// of the recording even though a device was explicitly requested. Recording
+  /// apps that must stay on the built-in mic have no way to express that today.
+  ///
+  /// Deliberately a no-op when the wanted input is already current: calling
+  /// `setPreferredInput` forces a route change, which posts another
+  /// configuration change, which would call straight back into here.
+  func reapplyPreferredInputDevice(_ device: Device?) {
+    guard let device else { return }
+
+    let session = AVAudioSession.sharedInstance()
+    if session.currentRoute.inputs.first?.uid == device.id { return }
+
+    guard let inputs = session.availableInputs,
+          let match = inputs.first(where: { $0.uid == device.id }) else { return }
+
+    do {
+      try session.setPreferredInput(match)
+    } catch {
+      print("Unable to reapply the preferred input: \(error.localizedDescription)")
+    }
+  }
 }
 
 // MARK: - Session configuration steps

--- a/record_platform_interface/lib/src/types/ios_record_config.dart
+++ b/record_platform_interface/lib/src/types/ios_record_config.dart
@@ -16,6 +16,17 @@ class IosRecordConfig {
   /// https://developer.apple.com/documentation/avfaudio/avaudiosession/setallowhapticsandsystemsoundsduringrecording(_:)
   final bool allowHapticsAndSystemSoundsDuringRecording;
 
+  /// Recover from an `AVAudioEngine` configuration change (defaults to `false`).
+  ///
+  /// A route change (or another app reconfiguring the shared session) can stop
+  /// the engine without an interruption ever being posted, silently ending
+  /// capture. When `true`, the tap is reinstalled against the new input format
+  /// and the engine restarted on
+  /// `AVAudioEngine.configurationChangeNotification`.
+  ///
+  /// https://developer.apple.com/documentation/avfaudio/avaudioengine/configurationchangenotification
+  final bool restartOnEngineConfigurationChange;
+
   const IosRecordConfig({
     this.categoryOptions = const [
       IosAudioCategoryOption.defaultToSpeaker,
@@ -23,12 +34,14 @@ class IosRecordConfig {
       IosAudioCategoryOption.allowBluetoothA2DP,
     ],
     this.allowHapticsAndSystemSoundsDuringRecording = false,
+    this.restartOnEngineConfigurationChange = false,
   });
   Map<String, dynamic> toMap() {
     return {
       "categoryOptions": categoryOptions.map((e) => e.name).join(','),
       "allowHapticsAndSystemSoundsDuringRecording":
           allowHapticsAndSystemSoundsDuringRecording,
+      "restartOnEngineConfigurationChange": restartOnEngineConfigurationChange,
     };
   }
 }


### PR DESCRIPTION
## Problem

On iOS, `RecorderStreamDelegate` only observes `AVAudioSession.interruptionNotification`. A route change (headset connect/disconnect, another app reconfiguring the shared session) posts `AVAudioEngineConfigurationChangeNotification` instead, which stops the engine without any interruption ever firing — capture ends silently, with no state change for callers to observe. `AVAudioEngine` does not restart itself after this notification; per Apple's docs the caller is expected to reinstall the tap against the (possibly changed) input format and start the engine again.

## Fix

Adds an observer for `AVAudioEngine.configurationChangeNotification` scoped to the engine instance. On fire: remove the tap, re-read `inputNode.inputFormat`, rebuild the `AudioStreamProcessor` against it, reinstall the tap, and restart the engine — the same sequence `start()` already does. On success this calls `onRecord()` same as the interruption-resume path, so callers observing `RecordState` see the recovery. On failure it calls `stop()` rather than leaving the engine silently wedged.

Opt-in via a new `IosRecordConfig.restartOnEngineConfigurationChange` (default `false`), so this is a no-op for existing callers and only changes behavior for those who ask for it.

## Testing

Not yet device-tested — I'm about to wire this into my own app via a git override on this branch and will report back with real results (route changes, Bluetooth connect/disconnect, another app taking the session) once I have them. Opening the PR now for early feedback on the approach/flag naming while I do that.