### PR TITLE
fix(ios): avoid installTap sample-rate assertion crash when starting stream recording

### DIFF
--- a/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
+++ b/record_ios/ios/record_ios/Sources/record_ios/delegate/RecorderStreamDelegate.swift
@@ -32,11 +32,40 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
   }
 
   func start(config: RecordConfig, recordEventHandler: RecordStreamHandler) throws {
-    let engine = AVAudioEngine()
+    // Configure the audio session before creating the engine: category /
+    // activation / preferred sample rate changes may trigger an asynchronous
+    // hardware sample rate switch, and an engine created beforehand can end
+    // up observing a stale input format.
     m_interruptionObserver = try initAVAudioSession(config: config, manageAudioSession: m_manageAudioSession, queue: m_queue)
-    try setVoiceProcessing(echoCancel: config.echoCancel, autoGain: config.autoGain, audioEngine: engine)
 
-    let srcFormat = engine.inputNode.inputFormat(forBus: 0)
+    // Wait for the input format to settle before installing the tap.
+    // While a hardware sample rate switch (session reconfiguration, Bluetooth
+    // HFP/A2DP negotiation, headphone route change) is still in progress,
+    // inputFormat(forBus:) can return a stale sample rate. installTap then
+    // hits the AVFAudio assertion
+    //   'required condition is false: format.sampleRate == hwFormat.sampleRate'
+    // which is raised as an NSException — uncatchable from Swift — and aborts
+    // the process (SIGABRT). The engine is re-created on each retry because
+    // the input node caches the format it first observed.
+    var engine = AVAudioEngine()
+    try setVoiceProcessing(echoCancel: config.echoCancel, autoGain: config.autoGain, audioEngine: engine)
+    var srcFormat = engine.inputNode.inputFormat(forBus: m_bus)
+    var tries = 0
+    while !isFormatSettled(srcFormat, config: config), tries < 10 {
+      // Runs on the plugin's background serial queue, not the main thread.
+      usleep(25_000)
+      engine = AVAudioEngine()
+      try setVoiceProcessing(echoCancel: config.echoCancel, autoGain: config.autoGain, audioEngine: engine)
+      srcFormat = engine.inputNode.inputFormat(forBus: m_bus)
+      tries += 1
+    }
+    guard srcFormat.sampleRate > 0, srcFormat.channelCount > 0 else {
+      throw RecorderError.error(
+        message: "Failed to start recording",
+        details: "Input format unavailable (rate=\(srcFormat.sampleRate), ch=\(srcFormat.channelCount))"
+      )
+    }
+
     let processor = try AudioStreamProcessor(config: config, srcFormat: srcFormat)
 
     engine.inputNode.installTap(
@@ -59,6 +88,16 @@ class RecorderStreamDelegate: NSObject, AudioRecordingStreamDelegate {
     m_lock.withLock { m_processor = processor }
     self.config = config
     m_onRecord()
+  }
+
+  // Whether the input format is usable for installTap: non-zero, and (unless
+  // voice processing is enabled) matching the session's hardware sample rate.
+  // With voice processing enabled the input node format may legitimately
+  // differ from the hardware sample rate.
+  private func isFormatSettled(_ format: AVAudioFormat, config: RecordConfig) -> Bool {
+    guard format.sampleRate > 0, format.channelCount > 0 else { return false }
+    guard !config.echoCancel else { return true }
+    return abs(format.sampleRate - AVAudioSession.sharedInstance().sampleRate) < 1.0
   }
 
   @discardableResult


### PR DESCRIPTION
Addresses #622 (full root-cause analysis there).

`RecorderStreamDelegate.start()` can abort the whole app with an uncatchable NSException (`required condition is false: format.sampleRate == hwFormat.sampleRate`) when `installTap` runs while an asynchronous hardware sample-rate switch (session reconfiguration, Bluetooth HFP/A2DP negotiation, route change) is still in progress and `inputFormat(forBus:)` returned a stale format.

### Changes (pure Swift, no API change)

1. **Configure the session before creating the engine.** Upstream order is engine → `initAVAudioSession`; since session configuration (category/activation/preferred sample rate) is what triggers the async hardware switch, creating the engine afterwards removes the structural half of the race.
2. **Wait for the input format to settle before `installTap`.** Poll until the format is non-zero and (unless voice processing is enabled, where the input node format may legitimately differ) matches `AVAudioSession.sampleRate`. The engine is re-created per retry because the input node caches the first format it observed. Bounded at 10×25 ms on the plugin's background serial queue — in normal operation it takes 0 rounds, so the happy path is unchanged. If no valid format shows up, a `RecorderError` is thrown instead of tripping the AVFAudio assertion.

### Testing

- Device-matrix regression of our voice-interaction flow (repeated stream starts with Bluetooth headset connect/disconnect and wired-headphone plug/unplug loops): the assertion crash no longer reproduces; the format-settle loop measures 0 wait rounds in normal operation.
- This change (as part of a vendored fork) is rolling out in our production app for children's voice exercises; the crash signature came from real production crash reports against record_ios 2.1.1.

Note: a third, defense-in-depth layer (ObjC `@try/@catch` around `installTap`/`prepare`/`start` so any residual race becomes a catchable `PlatformException` instead of SIGABRT) is deliberately not included — it needs an ObjC file and a single SPM target can't mix languages. See #622 for discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
