### PR TITLE
fix(web): startStream never completes when getUserMedia rejects

### DIFF
--- a/record_web/lib/src/recorder/delegate/mic_recorder_delegate.dart
+++ b/record_web/lib/src/recorder/delegate/mic_recorder_delegate.dart
@@ -82,15 +82,14 @@ class MicRecorderDelegate extends RecorderDelegate {
 
   @override
   Future<Stream<Uint8List>> startStream(RecordConfig config) async {
-    await _recordStreamCtrl?.close();
+    _closeRecordStream();
     _recordStreamCtrl = StreamController<Uint8List>();
 
     try {
       await _start(config, isStream: true);
     } catch (err) {
       debugPrint(err.toString());
-      await _recordStreamCtrl?.close();
-      _recordStreamCtrl = null;
+      _closeRecordStream();
       rethrow;
     }
 
@@ -227,6 +226,15 @@ class MicRecorderDelegate extends RecorderDelegate {
     _maxAmplitude = kMinAmplitude;
     _amplitude = kMinAmplitude;
 
+    _closeRecordStream();
+  }
+
+  /// Never awaits [StreamController.close]: its future is the controller's
+  /// `done` future, which for a single-subscription stream only completes
+  /// once a listener has received the done event. After a failed start the
+  /// stream was never handed out, so nobody listens and the await would
+  /// never return (startStream neither resolved nor threw).
+  void _closeRecordStream() {
     _recordStreamCtrl?.close();
     _recordStreamCtrl = null;
   }


### PR DESCRIPTION
Fixes #624.

## Problem

On web, `startStream()` never completes (neither resolves nor throws) when `getUserMedia` rejects: microphone blocked in site settings, prompt dismissed, no input device, and so on.

`MicRecorderDelegate.startStream` creates a single-subscription `StreamController`, and on failure awaits `close()` on it before rethrowing. That controller's stream has not been handed to the caller yet, so nobody listens to it. `StreamController.close()` returns the `done` future, which for a single-subscription stream only completes once a listener has received the done event. With no listener it never completes, so the `await` never returns and the `rethrow` is never reached. The same `await _recordStreamCtrl?.close()` sits at the top of `startStream`, so a second attempt after a failed one blocks there too.

## Fix

Close the record stream controller without awaiting it (a small `_closeRecordStream()` helper used in `startStream` and `_reset`). Closing an unlistened single-subscription controller is safe; there is nothing to flush.

## Verification

Ran the test from #624 in headless Chrome (`flutter test --platform chrome`, web plugin registered by hand) against:

- published `record_web` 2.1.2: the plugin's `debugPrint` shows `NotAllowedError: Permission denied` being caught, but `startStream` is still pending 3 s later.
- this branch: `startStream` throws `NotAllowedError: Permission denied` right away.

No changelog / version bump included; happy to add whichever you prefer.
